### PR TITLE
Combine listener interface callbacks into single method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+    ext.kotlin_version = '1.2.50'
+
     repositories {
         google()
         jcenter()
@@ -37,6 +38,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -137,12 +137,12 @@ final class ButtonInternalImpl implements ButtonInternal {
             DeviceManager deviceManager) {
 
         if (buttonRepository.getApplicationId() == null) {
-            listener.onNoPostInstallIntent(new ApplicationIdNotFoundException());
+            listener.onResult(null, new ApplicationIdNotFoundException());
             return;
         }
 
         if (deviceManager.isOldInstallation() || buttonRepository.checkedDeferredDeepLink()) {
-            listener.onNoPostInstallIntent(null);
+            listener.onResult(null, null);
             return;
         }
 
@@ -162,16 +162,16 @@ final class ButtonInternalImpl implements ButtonInternal {
                         setAttributionToken(buttonRepository, attribution.getBtnRef());
                     }
 
-                    listener.onPostInstallIntent(deepLinkIntent);
+                    listener.onResult(deepLinkIntent, null);
                     return;
                 }
 
-                listener.onNoPostInstallIntent(null);
+                listener.onResult(null, null);
             }
 
             @Override
             public void onTaskError(Throwable throwable) {
-                listener.onNoPostInstallIntent(throwable);
+                listener.onResult(null, throwable);
             }
         }, deviceManager);
     }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -82,7 +82,7 @@ final class ButtonInternalImpl implements ButtonInternal {
             @NonNull Order order, @Nullable final UserActivityListener listener) {
         if (buttonRepository.getApplicationId() == null) {
             if (listener != null) {
-                listener.onError(new ApplicationIdNotFoundException());
+                listener.onResult(new ApplicationIdNotFoundException());
             }
 
             return;
@@ -93,14 +93,14 @@ final class ButtonInternalImpl implements ButtonInternal {
             @Override
             public void onTaskComplete(@Nullable Object object) {
                 if (listener != null) {
-                    listener.onSuccess();
+                    listener.onResult(null);
                 }
             }
 
             @Override
             public void onTaskError(Throwable throwable) {
                 if (listener != null) {
-                    listener.onError(throwable);
+                    listener.onResult(throwable);
                 }
             }
         };

--- a/button-merchant/src/main/java/com/usebutton/merchant/PostInstallIntentListener.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/PostInstallIntentListener.java
@@ -26,22 +26,22 @@
 package com.usebutton.merchant;
 
 import android.content.Intent;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
  * Callbacks for post-install intent handler.
  */
 public interface PostInstallIntentListener {
-
     /**
-     * A post-install url was found. You are responsible for navigating the user
-     * -to the appropriate content by starting the attached intent.
+     * This callback is used to notify the application that the request to check for a post-app
+     * install deep link is complete. If a deep link was found, it will be returned here. If an
+     * error was encountered while making the request, it will optionally be returned here.
+     *
+     * @param intent if a post-install link was found it will be returned here in the intent data.
+     * The intent can be started to navigate the user to the appropriate location in the app. If no
+     * post-install intent was found, this param will be {@code null}.
+     * @param t if an error was encountered while making the request it will be returned in this
+     * param, otherwise {@code null}.
      */
-    void onPostInstallIntent(@NonNull Intent intent);
-
-    /**
-     * No post-install url was found. Continue with your normal launch sequence.
-     */
-    void onNoPostInstallIntent(@Nullable Throwable t);
+    void onResult(@Nullable Intent intent, @Nullable Throwable t);
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/UserActivityListener.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/UserActivityListener.java
@@ -33,7 +33,5 @@ import android.support.annotation.Nullable;
  * @see ButtonMerchant#trackOrder(android.content.Context, Order, UserActivityListener)
  */
 public interface UserActivityListener {
-    void onSuccess();
-
-    void onError(@Nullable Throwable t);
+    void onResult(@Nullable Throwable t);
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -297,8 +297,7 @@ public class ButtonInternalImplTest {
 
         listenerArgumentCaptor.getValue().onTaskComplete(postInstallLink);
 
-        verify(postInstallIntentListener).onPostInstallIntent(any(Intent.class));
-        verify(postInstallIntentListener, never()).onNoPostInstallIntent(any(Throwable.class));
+        verify(postInstallIntentListener).onResult(any(Intent.class), (Throwable) isNull());
         verify(buttonRepository).setSourceToken("valid_source_token");
     }
 
@@ -324,8 +323,7 @@ public class ButtonInternalImplTest {
 
         listenerArgumentCaptor.getValue().onTaskComplete(postInstallLink);
 
-        verify(postInstallIntentListener, never()).onPostInstallIntent(any(Intent.class));
-        verify(postInstallIntentListener).onNoPostInstallIntent((Throwable) isNull());
+        verify(postInstallIntentListener).onResult(null, null);
         verify(buttonRepository, never()).setSourceToken(anyString());
     }
 
@@ -343,9 +341,8 @@ public class ButtonInternalImplTest {
 
         verify(buttonRepository, never()).getPendingLink(any(Task.Listener.class),
                 any(DeviceManager.class));
-        verify(postInstallIntentListener, never()).onPostInstallIntent(any(Intent.class));
         verify(buttonRepository, never()).setSourceToken(anyString());
-        verify(postInstallIntentListener).onNoPostInstallIntent(
+        verify(postInstallIntentListener).onResult((Intent) isNull(),
                 any(ApplicationIdNotFoundException.class));
     }
 
@@ -368,8 +365,8 @@ public class ButtonInternalImplTest {
 
         listenerArgumentCaptor.getValue().onTaskError(new ButtonNetworkException(""));
 
-        verify(postInstallIntentListener).onNoPostInstallIntent(any(ButtonNetworkException.class));
-        verify(postInstallIntentListener, never()).onPostInstallIntent(any(Intent.class));
+        verify(postInstallIntentListener).onResult((Intent) isNull(),
+                any(ButtonNetworkException.class));
     }
 
     @Test
@@ -404,7 +401,7 @@ public class ButtonInternalImplTest {
                 "com.usebutton.merchant",
                 deviceManager);
 
-        verify(postInstallIntentListener).onNoPostInstallIntent((Throwable) isNull());
+        verify(postInstallIntentListener).onResult(null, null);
         verify(buttonRepository, never()).updateCheckDeferredDeepLink(anyBoolean());
     }
 
@@ -422,7 +419,7 @@ public class ButtonInternalImplTest {
                 "com.usebutton.merchant",
                 deviceManager);
 
-        verify(postInstallIntentListener).onNoPostInstallIntent((Throwable) isNull());
+        verify(postInstallIntentListener).onResult((Intent) isNull(), (Throwable) isNull());
         verify(buttonRepository, never()).updateCheckDeferredDeepLink(anyBoolean());
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -121,7 +121,7 @@ public class ButtonInternalImplTest {
         buttonInternal.trackOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class),
                 listener);
 
-        verify(listener).onError(any(ApplicationIdNotFoundException.class));
+        verify(listener).onResult(any(ApplicationIdNotFoundException.class));
         verify(buttonRepository, never()).postUserActivity(any(DeviceManager.class),
                 any(Order.class),
                 any(Task.Listener.class));
@@ -160,7 +160,7 @@ public class ButtonInternalImplTest {
 
         buttonInternal.trackOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class),
                 listener);
-        verify(listener).onSuccess();
+        verify(listener).onResult(null);
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ButtonInternalImplTest {
 
         buttonInternal.trackOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class),
                 listener);
-        verify(listener).onError(throwable);
+        verify(listener).onResult(throwable);
     }
 
     @Test

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,6 +24,7 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 def BUTTON_MERCHANT_API_KEY = hasProperty('buttonMerchantAppId') ? '"' + buttonMerchantAppId + '"'
         : '"app-1234567890abcdef"'
@@ -59,6 +60,7 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation "com.android.support:design:$supportLibVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "com.android.support.test:runner:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -41,29 +41,6 @@
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
-            <!--<intent-filter>-->
-                <!--<action android:name="android.intent.action.MAIN"/>-->
-                <!--<category android:name="android.intent.category.LAUNCHER"/>-->
-            <!--</intent-filter>-->
-            <!--<intent-filter>-->
-                <!--<action android:name="android.intent.action.VIEW"/>-->
-
-                <!--<category android:name="android.intent.category.DEFAULT"/>-->
-                <!--<category android:name="android.intent.category.BROWSABLE"/>-->
-
-                <!--<data-->
-                    <!--android:host="sample-merchant.usebutton.com"-->
-                    <!--android:scheme="https"/>-->
-                <!--<data-->
-                    <!--android:host="btnmerchant.bttn.io"-->
-                    <!--android:scheme="https"/>-->
-            <!--</intent-filter>-->
-        </activity>
-
-        <activity
-            android:name=".KotlinActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -82,6 +59,11 @@
                     android:scheme="https"/>
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".KotlinActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar"/>
 
     </application>
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -41,6 +41,29 @@
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
+            <!--<intent-filter>-->
+                <!--<action android:name="android.intent.action.MAIN"/>-->
+                <!--<category android:name="android.intent.category.LAUNCHER"/>-->
+            <!--</intent-filter>-->
+            <!--<intent-filter>-->
+                <!--<action android:name="android.intent.action.VIEW"/>-->
+
+                <!--<category android:name="android.intent.category.DEFAULT"/>-->
+                <!--<category android:name="android.intent.category.BROWSABLE"/>-->
+
+                <!--<data-->
+                    <!--android:host="sample-merchant.usebutton.com"-->
+                    <!--android:scheme="https"/>-->
+                <!--<data-->
+                    <!--android:host="btnmerchant.bttn.io"-->
+                    <!--android:scheme="https"/>-->
+            <!--</intent-filter>-->
+        </activity>
+
+        <activity
+            android:name=".KotlinActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -1,0 +1,106 @@
+package com.usebutton.merchant.sample
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.Toolbar
+import android.util.Log
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import com.usebutton.merchant.ButtonMerchant
+import com.usebutton.merchant.Order
+import com.usebutton.merchant.Order.Builder
+import com.usebutton.merchant.UserActivityListener
+import com.usebutton.merchant.sample.R.id
+import java.util.Random
+
+class KotlinActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        ButtonMerchant.trackIncomingIntent(this, intent)
+        val token = ButtonMerchant.getAttributionToken(this)
+        Log.d(TAG, "Attribution Token is $token")
+
+        val textView = findViewById<TextView>(R.id.attribution_token)
+        textView.text = ButtonMerchant.getAttributionToken(this)
+
+        checkForPostInstallIntent()
+        initTrackNewIntentButton()
+        initTackOrderButton()
+        initClearDataButton()
+        initAttributionTokenListener()
+    }
+
+    private fun checkForPostInstallIntent() {
+        ButtonMerchant.handlePostInstallIntent(this) { intent, t ->
+            if (intent != null) {
+                startActivity(intent)
+            } else if (t != null) {
+                Log.e(TAG, "Error checking post install intent", t)
+            }
+        }
+    }
+
+    private fun initTrackNewIntentButton() {
+        findViewById<View>(id.track_new_intent).setOnClickListener { v ->
+            val intent = Intent()
+            intent.data = Uri.parse(TEST_URL + Random().nextInt(100000))
+            ButtonMerchant.trackIncomingIntent(v.context, intent)
+        }
+    }
+
+    private fun initTackOrderButton() {
+        findViewById<View>(id.track_order).setOnClickListener {
+            val order = Builder("order-id-123")
+                    .setAmount(8999)
+                    .setCurrencyCode("USD")
+                    .build()
+            ButtonMerchant.trackOrder(this, order) { t ->
+                if (t == null) {
+                    toastify("Order track success")
+                } else {
+                    toastify("Order track error")
+                }
+            }
+        }
+    }
+
+    private fun initClearDataButton() {
+        findViewById<View>(id.clear_all_data).setOnClickListener {
+            ButtonMerchant.clearAllData(this)
+            Log.d(TAG, "Cleared all data")
+
+            val token = ButtonMerchant.getAttributionToken(this)
+            Log.d(TAG, "Attribution Token is $token")
+
+            val textView = findViewById<TextView>(id.attribution_token)
+            textView.text = ButtonMerchant.getAttributionToken(this)
+        }
+    }
+
+    private fun initAttributionTokenListener() {
+        ButtonMerchant.addAttributionTokenListener(this) { token ->
+            runOnUiThread {
+                findViewById<TextView>(id.attribution_token).text = token
+            }
+        }
+    }
+
+    private fun toastify(message: String) {
+        runOnUiThread {
+            Toast.makeText(this@KotlinActivity, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    companion object {
+        private const val TAG = "KotlinActivity"
+        private const val TEST_URL = "https://sample-merchant.usebutton.com/?btn_ref=srctok-test"
+    }
+}

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -12,9 +12,7 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import com.usebutton.merchant.ButtonMerchant
-import com.usebutton.merchant.Order
 import com.usebutton.merchant.Order.Builder
-import com.usebutton.merchant.UserActivityListener
 import com.usebutton.merchant.sample.R.id
 import java.util.Random
 

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
@@ -102,5 +104,27 @@ class KotlinActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "KotlinActivity"
         private const val TEST_URL = "https://sample-merchant.usebutton.com/?btn_ref=srctok-test"
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        val kotlinItem = menu.findItem(R.id.action_switch_kotlin)
+        val javaItem = menu.findItem(R.id.action_switch_java)
+        kotlinItem.isVisible = false
+        javaItem.isVisible = true
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.action_switch_kotlin -> {
+            }
+            R.id.action_switch_java -> {
+                val i = Intent(this@KotlinActivity, MainActivity::class.java)
+                finish()
+                startActivity(i)
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -34,6 +34,8 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -145,5 +147,29 @@ public class MainActivity extends AppCompatActivity {
                         });
                     }
                 });
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.main_menu, menu);
+        MenuItem javaItem = menu.findItem(R.id.action_switch_java);
+        MenuItem kotlinItem = menu.findItem(R.id.action_switch_kotlin);
+        javaItem.setVisible(false);
+        kotlinItem.setVisible(true);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.action_switch_java:
+                break;
+            case R.id.action_switch_kotlin:
+                Intent i = new Intent(MainActivity.this, KotlinActivity.class);
+                finish();
+                startActivity(i);
+                break;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -88,23 +88,17 @@ public class MainActivity extends AppCompatActivity {
                         .build();
                 ButtonMerchant.trackOrder(context, order, new UserActivityListener() {
                     @Override
-                    public void onSuccess() {
+                    public void onResult(@Nullable final Throwable t) {
                         runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                Toast.makeText(context, "Order track success",
-                                        Toast.LENGTH_SHORT).show();
-                            }
-                        });
-                    }
-
-                    @Override
-                    public void onError(@Nullable Throwable t) {
-                        runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                Toast.makeText(MainActivity.this, "Order track error",
-                                        Toast.LENGTH_SHORT).show();
+                                if (t == null) {
+                                    Toast.makeText(context, "Order track success",
+                                            Toast.LENGTH_SHORT).show();
+                                } else {
+                                    Toast.makeText(MainActivity.this, "Order track error",
+                                            Toast.LENGTH_SHORT).show();
+                                }
                             }
                         });
                     }

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -68,16 +68,12 @@ public class MainActivity extends AppCompatActivity {
 
         ButtonMerchant.handlePostInstallIntent(this, new PostInstallIntentListener() {
             @Override
-            public void onPostInstallIntent(@NonNull Intent intent) {
-                if (intent.getData() != null) {
-                    Log.d(TAG, "onPostInstallIntent: " + intent + " btn_ref: "
-                            + intent.getData().getQueryParameter("btn_ref"));
+            public void onResult(@Nullable Intent intent, @Nullable Throwable t) {
+                if (intent != null) {
+                    startActivity(intent);
+                } else if (t != null) {
+                    Log.e(TAG, "Error checking post install intent", t);
                 }
-            }
-
-            @Override
-            public void onNoPostInstallIntent(@Nullable Throwable t) {
-                Log.d(TAG, "onNoPostInstallIntent", t);
             }
         });
 

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -169,6 +169,8 @@ public class MainActivity extends AppCompatActivity {
                 finish();
                 startActivity(i);
                 break;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/sample/src/main/res/menu/main_menu.xml
+++ b/sample/src/main/res/menu/main_menu.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ strings.xml
+  ~ main_menu.xml
   ~
   ~ Copyright (c) 2018 Button, Inc. (https://usebutton.com)
   ~
@@ -23,9 +24,16 @@
   ~
   -->
 
-<resources>
-    <string name="app_name">Button Merchant</string>
-    <string name="action_settings">Settings</string>
-    <string name="action_switch_java">Switch to Java</string>
-    <string name="action_switch_kotlin">Switch to Kotlin</string>
-</resources>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_switch_java"
+        android:orderInCategory="1"
+        android:title="@string/action_switch_java"
+        app:showAsAction="ifRoom|collapseActionView"/>
+    <item
+        android:id="@+id/action_switch_kotlin"
+        android:orderInCategory="1"
+        android:title="@string/action_switch_kotlin"
+        app:showAsAction="ifRoom|collapseActionView"/>
+</menu>


### PR DESCRIPTION
### Goals :soccer:
Combine listener interface callbacks into single method to allow more concise syntax in Kotlin.

### Implementation :construction:
* Combines `PostInstallIntentListener` callbacks into a single method with nullable params.
* Combines `UserActivityListner` callbacks into a single method with nullable params.

### Testing :mag:
* Updates callback methods in unit tests.
* Adds a Kotlin activity to the sample application.
