### PR TITLE
Ensure public callbacks are ran on the main thread

### DIFF
--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -55,6 +55,7 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+        unitTests.includeAndroidResources = true
     }
 }
 
@@ -106,6 +107,7 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    testImplementation "org.robolectric:robolectric:3.8"
     testImplementation 'org.json:json:20171018'
     androidTestImplementation "com.android.support.test:runner:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -31,6 +31,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -43,8 +44,9 @@ public final class ButtonMerchant {
 
     }
 
+    private static Executor executor = new MainThreadExecutor();
     @VisibleForTesting
-    static ButtonInternal buttonInternal = new ButtonInternalImpl();
+    static ButtonInternal buttonInternal = new ButtonInternalImpl(executor);
 
     private static ExecutorService executorService = Executors.newSingleThreadExecutor();
 
@@ -87,13 +89,13 @@ public final class ButtonMerchant {
      *
      * For attribution to work correctly, you must:
      * <ul>
-     *     <li>Always access this token directly—*never cache it*.</li>
-     *     <li>Never manage the lifecycle of this token—Button manages the token validity window
-     *         server-side.</li>
-     *     <li>Always include this value when reporting orders to your order API.</li>
+     * <li>Always access this token directly—*never cache it*.</li>
+     * <li>Never manage the lifecycle of this token—Button manages the token validity window
+     * server-side.</li>
+     * <li>Always include this value when reporting orders to your order API.</li>
      * </ul>
      *
-     *  @return the last tracked Button attribution token.
+     * @return the last tracked Button attribution token.
      **/
     @Nullable
     public static String getAttributionToken(@NonNull Context context) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/MainThreadExecutor.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/MainThreadExecutor.java
@@ -1,0 +1,45 @@
+/*
+ * MainThreadExecutor.java
+ *
+ * Copyright (c) 2018 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Ensures that a given {@link Runnable} is posted and ran on the main thread.
+ */
+final class MainThreadExecutor implements Executor {
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void execute(@NonNull Runnable command) {
+        handler.post(command);
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -27,6 +27,7 @@ package com.usebutton.merchant;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 
 import com.usebutton.merchant.exception.ApplicationIdNotFoundException;
 import com.usebutton.merchant.exception.ButtonNetworkException;
@@ -36,6 +37,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,10 +57,12 @@ import static org.mockito.Mockito.when;
 public class ButtonInternalImplTest {
 
     private ButtonInternalImpl buttonInternal;
+    private Executor executor;
 
     @Before
     public void setUp() {
-        buttonInternal = new ButtonInternalImpl();
+        executor = new TestMainThreadExecutor();
+        buttonInternal = new ButtonInternalImpl(executor);
     }
 
     @Test
@@ -421,5 +426,13 @@ public class ButtonInternalImplTest {
 
         verify(postInstallIntentListener).onResult((Intent) isNull(), (Throwable) isNull());
         verify(buttonRepository, never()).updateCheckDeferredDeepLink(anyBoolean());
+    }
+
+    private class TestMainThreadExecutor implements Executor {
+
+        @Override
+        public void execute(@NonNull Runnable command) {
+            command.run();
+        }
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/MainThreadExecutorTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/MainThreadExecutorTest.java
@@ -1,0 +1,60 @@
+/*
+ * MainThreadExecutorTest.java
+ *
+ * Copyright (c) 2018 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.os.Looper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class MainThreadExecutorTest {
+
+    private Executor executor = new MainThreadExecutor();
+
+    @Test
+    public void executor_shouldExecute() throws Exception {
+        final boolean[] executed = { false };
+
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(Looper.myLooper(), Looper.getMainLooper());
+                executed[0] = true;
+            }
+        });
+
+        Robolectric.flushForegroundThreadScheduler();
+        assertTrue(executed[0]);
+    }
+}

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -87,16 +87,12 @@ class KotlinActivity : AppCompatActivity() {
 
     private fun initAttributionTokenListener() {
         ButtonMerchant.addAttributionTokenListener(this) { token ->
-            runOnUiThread {
-                findViewById<TextView>(id.attribution_token).text = token
-            }
+            findViewById<TextView>(id.attribution_token).text = token
         }
     }
 
     private fun toastify(message: String) {
-        runOnUiThread {
-            Toast.makeText(this@KotlinActivity, message, Toast.LENGTH_SHORT).show()
-        }
+        Toast.makeText(this@KotlinActivity, message, Toast.LENGTH_SHORT).show()
     }
 
     companion object {

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -91,18 +91,13 @@ public class MainActivity extends AppCompatActivity {
                 ButtonMerchant.trackOrder(context, order, new UserActivityListener() {
                     @Override
                     public void onResult(@Nullable final Throwable t) {
-                        runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (t == null) {
-                                    Toast.makeText(context, "Order track success",
-                                            Toast.LENGTH_SHORT).show();
-                                } else {
-                                    Toast.makeText(MainActivity.this, "Order track error",
-                                            Toast.LENGTH_SHORT).show();
-                                }
-                            }
-                        });
+                        if (t == null) {
+                            Toast.makeText(context, "Order track success",
+                                    Toast.LENGTH_SHORT).show();
+                        } else {
+                            Toast.makeText(MainActivity.this, "Order track error",
+                                    Toast.LENGTH_SHORT).show();
+                        }
                     }
                 });
             }
@@ -138,13 +133,8 @@ public class MainActivity extends AppCompatActivity {
                 new ButtonMerchant.AttributionTokenListener() {
                     @Override
                     public void onAttributionTokenChanged(@NonNull final String token) {
-                        runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                TextView textView = findViewById(R.id.attribution_token);
-                                textView.setText(token);
-                            }
-                        });
+                        TextView textView = findViewById(R.id.attribution_token);
+                        textView.setText(token);
                     }
                 });
     }


### PR DESCRIPTION
### Goals :soccer:
Users of the library can safely run UI related code within public callbacks.

### Implementation :construction:
Create a `MainThreadExecutor` that posts any passed Runnables to an internal Handler, which ensures that said Runnable executes on the main thread.

### Testing :mag:
Constructing the `ButtonInternalImpl` with a test Executor which runs the Runnable right away instead of posting it. This then allows each test to run synchronously.
