### PR TITLE
Add Application ID to all API requests

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -62,7 +62,7 @@ final class ButtonApiImpl implements ButtonApi {
     private final String userAgent;
 
     @VisibleForTesting
-    String baseUrl = "https://api.usebutton.com";
+    String baseUrl = "https://%s.mobileapi.usebutton.com";
 
     private static ButtonApi buttonApi;
 
@@ -96,7 +96,7 @@ final class ButtonApiImpl implements ButtonApi {
             requestBody.put("signals", new JSONObject(signalsMap));
 
             // setup url connection
-            final URL url = new URL(baseUrl + "/v1/web/deferred-deeplink");
+            final URL url = new URL(getBaseUrl(applicationId) + "/v1/web/deferred-deeplink");
             urlConnection = (HttpURLConnection) url.openConnection();
             initializeUrlConnection(urlConnection);
 
@@ -193,7 +193,7 @@ final class ButtonApiImpl implements ButtonApi {
             requestBody.put("source", "merchant-library");
 
             // setup url connection
-            final URL url = new URL(baseUrl + "/v1/activity/order");
+            final URL url = new URL(getBaseUrl(applicationId) + "/v1/activity/order");
             urlConnection = (HttpURLConnection) url.openConnection();
             initializeUrlConnection(urlConnection);
 
@@ -249,6 +249,10 @@ final class ButtonApiImpl implements ButtonApi {
         }
 
         return null;
+    }
+
+    String getBaseUrl(String applicationId) {
+        return String.format(baseUrl, applicationId);
     }
 
     private String getUserAgent() {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -30,6 +30,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.usebutton.merchant.exception.ApplicationIdNotFoundException;
 
@@ -41,8 +42,9 @@ import java.util.concurrent.Executor;
  * The methods in the ButtonInternalImpl class should never be public because it will only be used
  * by {@link ButtonMerchant}.
  */
-
 final class ButtonInternalImpl implements ButtonInternal {
+
+    private static final String TAG = ButtonInternal.class.getSimpleName();
 
     /**
      * A list of {@link ButtonMerchant.AttributionTokenListener}. All listeners will be notified of
@@ -66,6 +68,15 @@ final class ButtonInternalImpl implements ButtonInternal {
     }
 
     public void configure(ButtonRepository buttonRepository, String applicationId) {
+        final boolean isApplicationIdValid = ButtonUtil.isApplicationIdValid(applicationId);
+        if (!isApplicationIdValid) {
+            final String errorMessage = String.format(
+                    "Button App ID '%s' is not valid. You can find your App ID in the dashboard by"
+                            + " logging in at https://app.usebutton.com/", applicationId);
+            Log.e(TAG, errorMessage);
+            return;
+        }
+
         buttonRepository.setApplicationId(applicationId);
     }
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
@@ -25,6 +25,9 @@
 
 package com.usebutton.merchant;
 
+/**
+ * Utility Class
+ */
 class ButtonUtil {
     /**
      * Valid App Id Regex

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
@@ -1,0 +1,44 @@
+/*
+ * ButtonUtil.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+class ButtonUtil {
+    /**
+     * Valid App Id Regex
+     */
+    private static final String APP_ID_REGEX = "^app-[0-9a-zA-Z-]+$";
+
+    /**
+     * Validates the string against the {@link ButtonUtil#APP_ID_REGEX} to verify if it is a valid
+     * Application ID
+     *
+     * @param appId String to be validated.
+     * @return True if string is not empty and is a valid application id, otherwise false.
+     */
+    static boolean isApplicationIdValid(String appId) {
+        return appId.matches(APP_ID_REGEX);
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -40,12 +40,12 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static com.usebutton.merchant.TestHelper.APPLICATION_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class ButtonApiImplTest {
 
-    private static final String APPLICATION_ID = "app-124567890abcdef";
     private final String userAgent = "valid_user_agent";
 
     private MockWebServer server = new MockWebServer();

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class ButtonApiImplTest {
 
+    private static final String APPLICATION_ID = "app-124567890abcdef";
     private final String userAgent = "valid_user_agent";
 
     private MockWebServer server = new MockWebServer();
@@ -81,7 +82,7 @@ public class ButtonApiImplTest {
         });
 
         PostInstallLink postInstallLink =
-                buttonApi.getPendingLink("valid_application_id", "valid_ifa",
+                buttonApi.getPendingLink(APPLICATION_ID, "valid_ifa",
                         true, Collections.<String, String>emptyMap());
 
         assertNotNull(postInstallLink);
@@ -98,7 +99,7 @@ public class ButtonApiImplTest {
     public void getPendingLink_validateRequest() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa",
+        buttonApi.getPendingLink(APPLICATION_ID, "valid_ifa",
                 true, Collections.singletonMap("key", "value"));
 
         RecordedRequest recordedRequest = server.takeRequest();
@@ -116,7 +117,7 @@ public class ButtonApiImplTest {
         assertEquals("application/json", headers.get("Content-Type"));
 
         // request body
-        assertEquals("valid_application_id", bodyJson.getString("application_id"));
+        assertEquals(APPLICATION_ID, bodyJson.getString("application_id"));
         assertEquals("valid_ifa", bodyJson.getString("ifa"));
         assertEquals(true, bodyJson.getBoolean("ifa_limited"));
         assertEquals("value", signalsJson.getString("key"));
@@ -132,7 +133,7 @@ public class ButtonApiImplTest {
             }
         });
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa", true,
+        buttonApi.getPendingLink(APPLICATION_ID, "valid_ifa", true,
                 Collections.<String, String>emptyMap());
     }
 
@@ -151,7 +152,7 @@ public class ButtonApiImplTest {
             }
         });
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa", true,
+        buttonApi.getPendingLink(APPLICATION_ID, "valid_ifa", true,
                 Collections.<String, String>emptyMap());
     }
 
@@ -159,7 +160,7 @@ public class ButtonApiImplTest {
     public void getPendingLink_invalidUrl_catchException() throws Exception {
         buttonApi.baseUrl = "invalid_url";
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa", true,
+        buttonApi.getPendingLink(APPLICATION_ID, "valid_ifa", true,
                 Collections.<String, String>emptyMap());
     }
 
@@ -174,7 +175,7 @@ public class ButtonApiImplTest {
         });
 
         Order order = new Order.Builder("123").setCurrencyCode("AUG").build();
-        buttonApi.postActivity("valid_application_id", "valid_aid", "valid_ts", order);
+        buttonApi.postActivity(APPLICATION_ID, "valid_aid", "valid_ts", order);
     }
 
     @Test(expected = ButtonNetworkException.class)
@@ -194,7 +195,7 @@ public class ButtonApiImplTest {
         });
 
         Order order = new Order.Builder("123").setCurrencyCode("AUG").build();
-        buttonApi.postActivity("valid_application_id", "valid_aid", "valid_ts", order);
+        buttonApi.postActivity(APPLICATION_ID, "valid_aid", "valid_ts", order);
     }
 
     @Test(expected = ButtonNetworkException.class)
@@ -202,7 +203,7 @@ public class ButtonApiImplTest {
         buttonApi.baseUrl = "invalid_url";
 
         Order order = new Order.Builder("123").setCurrencyCode("AUG").build();
-        buttonApi.postActivity("valid_application_id", "valid_aid", "valid_ts", order);
+        buttonApi.postActivity(APPLICATION_ID, "valid_aid", "valid_ts", order);
     }
 
     @Test
@@ -211,7 +212,7 @@ public class ButtonApiImplTest {
                 .setBody("{\"meta\":{\"status\":\"ok\"}}\n"));
 
         Order order = new Order.Builder("123").setAmount(999).setCurrencyCode("AUG").build();
-        buttonApi.postActivity("valid_application_id", "valid_aid", "valid_ts", order);
+        buttonApi.postActivity(APPLICATION_ID, "valid_aid", "valid_ts", order);
 
         RecordedRequest recordedRequest = server.takeRequest();
         Headers headers = recordedRequest.getHeaders();
@@ -226,7 +227,7 @@ public class ButtonApiImplTest {
         assertEquals("application/json", headers.get("Content-Type"));
 
         // request body
-        assertEquals("valid_application_id", requestBodyJson.getString("app_id"));
+        assertEquals(APPLICATION_ID, requestBodyJson.getString("app_id"));
         assertEquals("valid_ts", requestBodyJson.getString("user_local_time"));
         assertEquals("valid_aid", requestBodyJson.getString("btn_ref"));
         assertEquals("123", requestBodyJson.getString("order_id"));
@@ -251,6 +252,17 @@ public class ButtonApiImplTest {
         });
 
         Order order = new Order.Builder("123").setCurrencyCode("AUG").build();
-        buttonApi.postActivity("valid_application_id", "valid_aid", "valid_ts", order);
+        buttonApi.postActivity(APPLICATION_ID, "valid_aid", "valid_ts", order);
+    }
+
+    @Test()
+    public void getBaseUrl_validateApplicationIdInUrl() {
+        // Reinitialize the buttonApi variable to reset the baseUrl back to the original.
+        buttonApi = new ButtonApiImpl(userAgent);
+
+        final String expectedUrl = "https://" +  APPLICATION_ID + ".mobileapi.usebutton.com";
+        final String actualUrl = buttonApi.getBaseUrl(APPLICATION_ID);
+
+        assertEquals(expectedUrl, actualUrl);
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -40,6 +40,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.Executor;
 
+import static com.usebutton.merchant.TestHelper.APPLICATION_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -69,17 +70,25 @@ public class ButtonInternalImplTest {
     public void configure_saveApplicationIdInMemory() {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
 
-        buttonInternal.configure(buttonRepository, "valid_application_id");
-        verify(buttonRepository).setApplicationId("valid_application_id");
+        buttonInternal.configure(buttonRepository, APPLICATION_ID);
+        verify(buttonRepository).setApplicationId(APPLICATION_ID);
+    }
+
+    @Test
+    public void configure_shouldNotSaveApplicationIdInMemory_InvalidAppId() {
+        ButtonRepository buttonRepository = mock(ButtonRepository.class);
+
+        buttonInternal.configure(buttonRepository, "invalid_application_id");
+        verify(buttonRepository, never()).setApplicationId(APPLICATION_ID);
     }
 
     @Test
     public void getApplicationId_retrieveFromRepository() {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
 
         String applicationId = buttonInternal.getApplicationId(buttonRepository);
-        assertEquals("valid_application_id", applicationId);
+        assertEquals(APPLICATION_ID, applicationId);
     }
 
     @Test
@@ -283,7 +292,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
 
         buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
                 "com.usebutton.merchant",
@@ -312,7 +321,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
 
         buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
                 "com.usebutton.merchant",
@@ -357,7 +366,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
 
         buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
                 "com.usebutton.merchant",
@@ -380,7 +389,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
         when(deviceManager.isOldInstallation()).thenReturn(false);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(false);
 
@@ -398,7 +407,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
         when(deviceManager.isOldInstallation()).thenReturn(true);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(false);
 
@@ -416,7 +425,7 @@ public class ButtonInternalImplTest {
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
 
-        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        when(buttonRepository.getApplicationId()).thenReturn(APPLICATION_ID);
         when(deviceManager.isOldInstallation()).thenReturn(false);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(true);
 

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonUtilTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * ButtonUtilTest.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import org.junit.Test;
+
+import static com.usebutton.merchant.TestHelper.APPLICATION_ID;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ButtonUtilTest {
+    @Test
+    public void isApplicationIdValid_ShouldReturnTrueWithValidAppId() {
+        assertTrue(ButtonUtil.isApplicationIdValid(APPLICATION_ID));
+    }
+
+    @Test
+    public void isApplicationIdValid_ShouldReturnFalseWithInvalidAppId_EmptyString() {
+        assertFalse(ButtonUtil.isApplicationIdValid(""));
+    }
+
+    @Test
+    public void isApplicationIdValid_ShouldReturnFalseWithInvalidAppId_NoAppPrefix() {
+        assertFalse(ButtonUtil.isApplicationIdValid("-1111111111111111"));
+    }
+
+    @Test
+    public void isApplicationIdValid_ShouldReturnFalseWithInvalidAppId_InvalidCharacter() {
+        assertFalse(ButtonUtil.isApplicationIdValid("app-992&&&&3   "));
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/TestHelper.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/TestHelper.java
@@ -1,0 +1,30 @@
+/*
+ * TestHelper.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+class TestHelper {
+    static final String APPLICATION_ID = "app-124567890abcdef";
+}


### PR DESCRIPTION
### Goals :soccer:
Update our Merchant Library to use application-id based hostnames: 
Ex. `https://app-1234123412341234.mobile-api.usebutton.com`

### Implementation :construction:
* URLs are now constructed using the new `String getBaseUrl(String applicationId)` method which injects the `applicationId` 
* `baseUrl` has changed from `https://api.usebutton.com` to `https://%s.mobileapi.usebutton.com`
* Added an `ButtonUtil.isApplicationIdValid` method to validate application id against a regex.
* Updated Tests
