### PR TITLE
Disables coveralls reporting on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,4 @@ script:
   - bash ./scripts/travis/run_tests.sh
 
 after_success:
-  - bash ./scripts/travis/coveralls.sh
   - bash ./scripts/travis/deploy_to_bintray.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.com/button/button-merchant-android.svg?token=csLDMWdyHoUrMqv9JzCZ&branch=master)](https://travis-ci.com/button/button-merchant-android)
-[![Coverage Status](https://coveralls.io/repos/github/button/button-merchant-android-private/badge.svg?branch=master&t=VbxDcA)](https://coveralls.io/github/button/button-merchant-android-private?branch=master)
 
 # Button Merchant Android
 An open source client library for Button merchants.


### PR DESCRIPTION
It does not seem possible to ignore individual files with coveralls,
hence disabling since it is becoming a blocker to workflow.

https://github.com/kt3k/coveralls-gradle-plugin/issues/62