### PR TITLE
Deprecate `trackOrder` Method

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -77,6 +77,7 @@ public final class ButtonMerchant {
      *
      * @param order {@link Order}
      * @param userActivityListener {@link UserActivityListener}
+     * @deprecated
      */
     public static void trackOrder(@NonNull Context context, @NonNull Order order,
             @Nullable UserActivityListener userActivityListener) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -79,6 +79,7 @@ public final class ButtonMerchant {
      * @param userActivityListener {@link UserActivityListener}
      * @deprecated
      */
+    @Deprecated
     public static void trackOrder(@NonNull Context context, @NonNull Order order,
             @Nullable UserActivityListener userActivityListener) {
         buttonInternal.trackOrder(getButtonRepository(context), getDeviceManager(context), order,


### PR DESCRIPTION
### Goals :soccer:
Deprecating the `trackOrder` method.

### Implementation :construction:
 * Add `@deprecated` annotation to the `trackOrder`