### PR TITLE
Re-Enable Coveralls + Add Ability to exclude certain files from report via Jacoco 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,5 @@ script:
   - bash ./scripts/travis/run_tests.sh
 
 after_success:
+  - bash ./scripts/travis/coveralls.sh
   - bash ./scripts/travis/deploy_to_bintray.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.com/button/button-merchant-android.svg?token=csLDMWdyHoUrMqv9JzCZ&branch=master)](https://travis-ci.com/button/button-merchant-android)
 
+[![Coverage Status](https://coveralls.io/repos/github/button/button-merchant-android-private/badge.svg?branch=master&t=VbxDcA)](https://coveralls.io/github/button/button-merchant-android-private?branch=master)
+
 # Button Merchant Android
 An open source client library for Button merchants.
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+        classpath 'org.jacoco:org.jacoco.core:0.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
-        classpath 'org.jacoco:org.jacoco.core:0.8.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -158,7 +158,6 @@ task jacocoReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
                       '**/Manifest*.*',
                       '**/*Test*.*',
                       'android/**/*.*',
-                      '**/data/models/*',
                       'com/usebutton/merchant/exception/**']
 
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -26,6 +26,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'jacoco'
 apply plugin: 'jacoco-android'
 
 group = 'com.usebutton.merchant'
@@ -146,10 +147,36 @@ artifacts {
     archives javadocJar
 }
 
+task jacocoReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class',
+                      '**/R$*.class',
+                      '**/BuildConfig.*',
+                      '**/Manifest*.*',
+                      '**/*Test*.*',
+                      'android/**/*.*',
+                      '**/data/models/*',
+                      'com/usebutton/merchant/exception/**']
+
+    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/connected/*coverage.ec"
+    ])
+}
+
 coveralls {
-    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml"
+    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoReport/jacocoReport.xml"
 }
 
 tasks.coveralls {
-    dependsOn 'jacocoTestDebugUnitTestReport'
+    dependsOn 'jacocoReport'
 }

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -26,7 +26,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'jacoco'
 apply plugin: 'jacoco-android'
 
 group = 'com.usebutton.merchant'


### PR DESCRIPTION
### Goals :soccer:
Adding the ability to exclude certain files from the coveralls coverage repost via jacoco.

### Implementation :construction:
 * Add gradle task `jacocoReport` that the `coveralls` task depends on which contains files excules. 

### Testing :mag:
 * Run `./gradlew coveralls` locally
 * Add a file in `com.usebutton.merchant` that has tests associated with it

Result : Code Coverage should increase when checking the coverage html report which is generated here `/button-merchant-android/build/reports/jacoco/jacocoReport/html/index.html`
