### PR TITLE
Added public key pinning

### DIFF
--- a/button-merchant/src/main/AndroidManifest.xml
+++ b/button-merchant/src/main/AndroidManifest.xml
@@ -27,5 +27,6 @@
     package="com.usebutton.merchant">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:networkSecurityConfig="@xml/network_security_config"/>
 
 </manifest>

--- a/button-merchant/src/main/res/xml/network_security_config.xml
+++ b/button-merchant/src/main/res/xml/network_security_config.xml
@@ -33,9 +33,4 @@
             <pin digest="SHA-256">47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=</pin>
         </pin-set>
     </domain-config>
-    <debug-overrides>
-        <trust-anchors>
-            <certificates src="user"/>
-        </trust-anchors>
-    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
### Goals :soccer:
Add the ability to pin the Merchant Library's network requests against a set of public keys.

### Implementation :construction:
Provided a network security config file as per the [standard integration approach](https://developer.android.com/training/articles/security-config) for Android 7 and above.

### Testing :mag:
- [x] Manual testing
