### PR TITLE
Added retry to order reporting

### DIFF
--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -158,7 +158,9 @@ task jacocoReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
                       '**/Manifest*.*',
                       '**/*Test*.*',
                       'android/**/*.*',
-                      'com/usebutton/merchant/exception/**']
+                      'com/usebutton/merchant/exception/**',
+                      'com/usebutton/merchant/ThreadManager.*'
+    ]
 
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
     def mainSrc = "${project.projectDir}/src/main/java"

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -120,6 +120,6 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     public void postOrder(Order order, DeviceManager deviceManager, Task.Listener listener) {
         executorService.submit(
                 new PostOrderTask(listener, buttonApi, order, getApplicationId(),
-                        getSourceToken(), deviceManager));
+                        getSourceToken(), deviceManager, new ThreadManager()));
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -30,6 +30,8 @@ import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.usebutton.merchant.exception.ButtonNetworkException;
+import com.usebutton.merchant.exception.HttpStatusException;
+import com.usebutton.merchant.exception.NetworkNotFoundException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -107,13 +109,16 @@ final class ConnectionManagerImpl implements ConnectionManager {
             if (responseCode >= 400) {
                 String message = "Unsuccessful Request. HTTP StatusCode: " + responseCode;
                 Log.e(TAG, message);
-                throw new ButtonNetworkException(message);
+                throw new HttpStatusException(message, responseCode);
             }
 
             JSONObject responseJson = readResponseBody(urlConnection);
             return new NetworkResponse(responseCode, responseJson);
-        } catch (IOException | JSONException e) {
-            Log.e(TAG, e.getClass().getSimpleName() + " has occurred", e);
+        } catch (IOException e) {
+            Log.e(TAG,"Error has occurred", e);
+            throw new NetworkNotFoundException(e);
+        } catch (JSONException e) {
+            Log.e(TAG,"Error has occurred", e);
             throw new ButtonNetworkException(e.getClass().getSimpleName() + " has occurred");
         } finally {
             if (urlConnection != null) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -115,10 +115,10 @@ final class ConnectionManagerImpl implements ConnectionManager {
             JSONObject responseJson = readResponseBody(urlConnection);
             return new NetworkResponse(responseCode, responseJson);
         } catch (IOException e) {
-            Log.e(TAG,"Error has occurred", e);
+            Log.e(TAG, "Error has occurred", e);
             throw new NetworkNotFoundException(e);
         } catch (JSONException e) {
-            Log.e(TAG,"Error has occurred", e);
+            Log.e(TAG, "Error has occurred", e);
             throw new ButtonNetworkException(e.getClass().getSimpleName() + " has occurred");
         } finally {
             if (urlConnection != null) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/PostOrderTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/PostOrderTask.java
@@ -98,7 +98,7 @@ class PostOrderTask extends Task {
 
         if (exception instanceof HttpStatusException) {
             HttpStatusException httpStatusException = (HttpStatusException) exception;
-            if (httpStatusException.wasRateLimited() || httpStatusException.wasServerError()) {
+            if (httpStatusException.wasServerError()) {
                 threadManager.sleep((long) delay);
                 return true;
             }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
@@ -1,0 +1,60 @@
+/*
+ * ThreadManager.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;/*
+ * com.usebutton.merchant.ThreadManager.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+/**
+ * Wrapper class for {@link Thread}
+ */
+class ThreadManager {
+
+    void sleep(long millis) throws InterruptedException {
+        Thread.sleep(millis);
+    }
+
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
@@ -23,30 +23,7 @@
  *
  */
 
-package com.usebutton.merchant;/*
- * com.usebutton.merchant.ThreadManager.java
- *
- * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- */
+package com.usebutton.merchant;
 
 /**
  * Wrapper class for {@link Thread}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ThreadManager.java
@@ -26,7 +26,7 @@
 package com.usebutton.merchant;
 
 /**
- * Wrapper class for {@link Thread}
+ * Wrapper class for {@link java.lang.Thread}
  */
 class ThreadManager {
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/exception/HttpStatusException.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/exception/HttpStatusException.java
@@ -1,0 +1,70 @@
+/*
+ * HttpStatusException.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant.exception;
+
+/**
+ * Network error with status code encountered when communicating with the Button API
+ */
+public class HttpStatusException extends ButtonNetworkException {
+    private final int statusCode;
+
+    public HttpStatusException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * @return true if status code falls in the range indicating bad requests. (400-499)
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+     */
+    public boolean wasBadRequest() {
+        return statusCode >= 400 && statusCode < 500;
+    }
+
+    /**
+     * @return if the exception was due to the server responding with a 401 (Unauthorized).
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+     */
+    public boolean wasUnauthorized() {
+        return statusCode == 401;
+    }
+
+    /**
+     * @return if the exception was due to the server responding with a 429 (Rate Limited).
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+     */
+    public boolean wasRateLimited() {
+        return statusCode == 429;
+    }
+
+    /**
+     * @return true if status code falls in the range indicating server errors. (500-599)
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+     */
+    public boolean wasServerError() {
+        return statusCode >= 500 && statusCode < 600;
+    }
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/exception/NetworkNotFoundException.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/exception/NetworkNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * NetworkNotFoundException.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant.exception;
+
+/**
+ * Network error encountered when communicating with the Button API
+ *
+ * ie. Device is not connected to the internet
+ */
+public class NetworkNotFoundException extends ButtonNetworkException {
+
+    public NetworkNotFoundException(Exception e) {
+        super(e);
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
@@ -57,6 +57,9 @@ public class PostOrderTaskTest {
     @Mock
     private Order order;
 
+    @Mock
+    private ThreadManager threadManager;
+
     private String applicationId = "valid_application_id";
     private String sourceToken = "valid_source_token";
 
@@ -66,7 +69,7 @@ public class PostOrderTaskTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         task = new PostOrderTask(listener, buttonApi, order, applicationId, sourceToken,
-                deviceManager);
+                deviceManager, threadManager);
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
@@ -93,35 +93,6 @@ public class PostOrderTaskTest {
     }
 
     @Test
-    public void execute_httpStatusException_wasRateLimited_verifyMaxRetry() throws Exception {
-        HttpStatusException httpStatusException = mock(HttpStatusException.class);
-        when(httpStatusException.wasRateLimited()).thenReturn(true);
-
-        when(buttonApi.postOrder(any(Order.class), anyString(),
-                anyString(), (String) isNull())).thenThrow(httpStatusException);
-
-        try {
-            task.execute();
-        } catch (Exception ignored) {
-
-        }
-
-        verify(buttonApi, times(MAX_RETRIES + 1))
-                .postOrder(any(Order.class), anyString(), anyString(), (String) isNull());
-    }
-
-    @Test(expected = HttpStatusException.class)
-    public void execute_httpStatusException_wasRateLimited_verifyThrowException() throws Exception {
-        HttpStatusException httpStatusException = mock(HttpStatusException.class);
-        when(httpStatusException.wasRateLimited()).thenReturn(true);
-
-        when(buttonApi.postOrder(any(Order.class), anyString(),
-                anyString(), (String) isNull())).thenThrow(httpStatusException);
-
-        task.execute();
-    }
-
-    @Test
     public void execute_httpStatusException_wasServerError_verifyMaxRetry() throws Exception {
         HttpStatusException httpStatusException = mock(HttpStatusException.class);
         when(httpStatusException.wasServerError()).thenReturn(true);

--- a/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/PostOrderTaskTest.java
@@ -25,13 +25,21 @@
 
 package com.usebutton.merchant;
 
+import com.usebutton.merchant.exception.HttpStatusException;
+import com.usebutton.merchant.exception.NetworkNotFoundException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static com.usebutton.merchant.PostOrderTask.MAX_RETRIES;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,5 +87,104 @@ public class PostOrderTaskTest {
         task.execute();
 
         verify(buttonApi).postOrder(eq(order), eq(applicationId), eq(sourceToken), (String) isNull());
+    }
+
+    @Test
+    public void execute_httpStatusException_wasRateLimited_verifyMaxRetry() throws Exception {
+        HttpStatusException httpStatusException = mock(HttpStatusException.class);
+        when(httpStatusException.wasRateLimited()).thenReturn(true);
+
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(httpStatusException);
+
+        try {
+            task.execute();
+        } catch (Exception ignored) {
+
+        }
+
+        verify(buttonApi, times(MAX_RETRIES + 1))
+                .postOrder(any(Order.class), anyString(), anyString(), (String) isNull());
+    }
+
+    @Test(expected = HttpStatusException.class)
+    public void execute_httpStatusException_wasRateLimited_verifyThrowException() throws Exception {
+        HttpStatusException httpStatusException = mock(HttpStatusException.class);
+        when(httpStatusException.wasRateLimited()).thenReturn(true);
+
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(httpStatusException);
+
+        task.execute();
+    }
+
+    @Test
+    public void execute_httpStatusException_wasServerError_verifyMaxRetry() throws Exception {
+        HttpStatusException httpStatusException = mock(HttpStatusException.class);
+        when(httpStatusException.wasServerError()).thenReturn(true);
+
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(httpStatusException);
+
+        try {
+            task.execute();
+        } catch (Exception ignored) {
+
+        }
+
+        verify(buttonApi, times(MAX_RETRIES + 1))
+                .postOrder(any(Order.class), anyString(), anyString(), (String) isNull());
+    }
+
+    @Test(expected = HttpStatusException.class)
+    public void execute_httpStatusException_wasServerError_verifyThrowException() throws Exception {
+        HttpStatusException httpStatusException = mock(HttpStatusException.class);
+        when(httpStatusException.wasServerError()).thenReturn(true);
+
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(httpStatusException);
+
+        task.execute();
+    }
+
+    @Test(expected = HttpStatusException.class)
+    public void execute_httpStatusException_verifyThrowException() throws Exception {
+        HttpStatusException httpStatusException = mock(HttpStatusException.class);
+
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(httpStatusException);
+
+        task.execute();
+    }
+
+    @Test
+    public void execute_networkNotFoundException_verifyMaxRetry() throws Exception {
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(NetworkNotFoundException.class);
+
+        try {
+            task.execute();
+        } catch (Exception ignored) {
+
+        }
+
+        verify(buttonApi, times(MAX_RETRIES + 1))
+                .postOrder(any(Order.class), anyString(), anyString(), (String) isNull());
+    }
+
+    @Test(expected = NetworkNotFoundException.class)
+    public void execute_networkNotFoundException_verifyThrowException() throws Exception {
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(NetworkNotFoundException.class);
+
+        task.execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void execute_exception_verifyThrowException() throws Exception {
+        when(buttonApi.postOrder(any(Order.class), anyString(),
+                anyString(), (String) isNull())).thenThrow(Exception.class);
+
+        task.execute();
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/exception/HttpStatusExceptionTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/exception/HttpStatusExceptionTest.java
@@ -1,0 +1,61 @@
+/*
+ * HttpStatusExceptionTest.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant.exception;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class HttpStatusExceptionTest {
+
+    @Test
+    public void wasBadRequest_verify() {
+        for (int statusCode = 400; statusCode < 500; statusCode++) {
+            HttpStatusException httpStatusException = new HttpStatusException("", statusCode);
+            assertTrue(httpStatusException.wasBadRequest());
+        }
+    }
+
+    @Test
+    public void wasUnauthorized_verify() {
+        HttpStatusException httpStatusException = new HttpStatusException("", 401);
+        assertTrue(httpStatusException.wasUnauthorized());
+    }
+
+    @Test
+    public void wasRateLimited_verify() {
+        HttpStatusException httpStatusException = new HttpStatusException("", 429);
+        assertTrue(httpStatusException.wasRateLimited());
+    }
+
+    @Test
+    public void wasServerError_verify() {
+        for (int statusCode = 500; statusCode < 600; statusCode++) {
+            HttpStatusException httpStatusException = new HttpStatusException("", statusCode);
+            assertTrue(httpStatusException.wasServerError());
+        }
+    }
+}


### PR DESCRIPTION
### Goals :soccer:
Added retry to order reporting 

### Implementation :construction:
* Added `HttpStatusException`
* Added `NetworkNotFoundException`
* Updated `PostOrderTask` to include while loop to retry the api request with exponential backoff when the device isn't connected to the internet, the api is rate limited, and there's an internal server error

### Testing :mag:
* Added tests cases retry logic
