### PR TITLE
Allow merchants to disable including ifa via features

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -31,6 +31,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import com.usebutton.merchant.module.Features;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -173,6 +175,15 @@ public final class ButtonMerchant {
             PostInstallIntentListener listener) {
         buttonInternal.handlePostInstallIntent(getButtonRepository(context), listener,
                 context.getPackageName(), getDeviceManager(context));
+    }
+
+    /**
+     * Button ML features configuration.
+     *
+     * @return Button features API
+     */
+    public static Features features() {
+        return FeaturesImpl.getInstance();
     }
 
     private static ButtonRepository getButtonRepository(Context context) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/FeaturesImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/FeaturesImpl.java
@@ -1,0 +1,61 @@
+/*
+ * FeaturesImpl.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import com.usebutton.merchant.module.Features;
+
+/**
+ * Class that handles controls merchant config for features
+ */
+final class FeaturesImpl implements Features {
+
+    private boolean includesIfa = true;
+
+    private static Features features;
+
+    static Features getInstance() {
+        if (features == null) {
+            features = new FeaturesImpl();
+        }
+
+        return features;
+    }
+
+    /**
+     * Include ifa in api requests
+     *
+     * @param includesIfa true or false
+     */
+    @Override
+    public void setIncludesIfa(boolean includesIfa) {
+        this.includesIfa = includesIfa;
+    }
+
+    public boolean includesIfa() {
+        return includesIfa;
+    }
+
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
@@ -26,7 +26,7 @@
 package com.usebutton.merchant.module;
 
 /**
- * Interface for features
+ * Interface to allow configuration of Merchant Library features
  */
 public interface Features {
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
@@ -1,0 +1,35 @@
+/*
+ * Features.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant.module;
+
+/**
+ * Interface for features
+ */
+public interface Features {
+
+    void setIncludesIfa(boolean includesIfa);
+
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -149,4 +150,10 @@ public class ButtonMerchantTest {
         verify(buttonInternal).reportOrder(any(ButtonRepository.class), any(DeviceManager.class),
                 eq(order), eq(orderListener));
     }
+
+    @Test
+    public void features_verifyInstanceType() {
+        assertTrue(ButtonMerchant.features() instanceof FeaturesImpl);
+    }
+
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/FeaturesImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/FeaturesImplTest.java
@@ -1,0 +1,54 @@
+/*
+ * FeaturesImplTest.java
+ *
+ * Copyright (c) 2019 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FeaturesImplTest {
+
+    private FeaturesImpl features;
+
+    @Before
+    public void setUp() {
+        features = new FeaturesImpl();
+    }
+
+    @Test
+    public void setIncludesIfa_verifyIncludesIfa() {
+        features.setIncludesIfa(false);
+
+        assertFalse(features.includesIfa());
+    }
+
+    @Test
+    public void includesIfa_verifyDefaultValue() {
+        assertTrue(features.includesIfa());
+    }
+}


### PR DESCRIPTION
### Goals :soccer:
Allow merchants to disable including ifa

### Implementation :construction:
* Added `Features` public interface
* Added `FeaturesImpl` class to handle functionality

### Testing :mag:
* Added tests to verify changes
