### PR TITLE
Updated including ifa in order reporting request to use features flag

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
@@ -39,8 +39,8 @@ interface ButtonApi {
 
     @Nullable
     @WorkerThread
-    PostInstallLink getPendingLink(String applicationId, String ifa,
-            boolean limitAdTrackingEnabled, Map<String, String> signalsMap)
+    PostInstallLink getPendingLink(String applicationId, @Nullable String advertisingId,
+            Map<String, String> signalsMap)
             throws ButtonNetworkException;
 
     @Nullable

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -65,16 +65,15 @@ final class ButtonApiImpl implements ButtonApi {
     @Nullable
     @WorkerThread
     @Override
-    public PostInstallLink getPendingLink(String applicationId, String ifa,
-            boolean limitAdTrackingEnabled, Map<String, String> signalsMap) throws
+    public PostInstallLink getPendingLink(String applicationId, @Nullable String advertisingId,
+            Map<String, String> signalsMap) throws
             ButtonNetworkException {
 
         try {
             // Create request body
             JSONObject requestBody = new JSONObject();
             requestBody.put("application_id", applicationId);
-            requestBody.put("ifa", ifa);
-            requestBody.put("ifa_limited", limitAdTrackingEnabled);
+            requestBody.put("ifa", advertisingId);
             requestBody.put("signals", new JSONObject(signalsMap));
 
             ApiRequest apiRequest = new ApiRequest.Builder(ApiRequest.RequestMethod.POST,

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -150,6 +150,7 @@ final class ButtonApiImpl implements ButtonApi {
             requestBody.put("order_id", order.getId());
             requestBody.put("purchase_date", ButtonUtil.formatDate(order.getPurchaseDate()));
             requestBody.put("customer_order_id", order.getCustomerOrderId());
+            requestBody.put("advertising_id", advertisingId);
 
             for (Order.LineItem lineItem : order.getLineItems()) {
                 JSONArray lineItemsJson = new JSONArray();
@@ -200,7 +201,6 @@ final class ButtonApiImpl implements ButtonApi {
                     customerJson.put("email_sha256", email);
                 }
 
-                customerJson.put("device_id", advertisingId);
                 requestBody.put("customer", customerJson);
             }
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
@@ -29,6 +29,8 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.usebutton.merchant.module.Features;
+
 /**
  * Internal implementation of the {@link ButtonMerchant} interface.
  */
@@ -58,6 +60,6 @@ interface ButtonInternal {
     void handlePostInstallIntent(ButtonRepository buttonRepository,
             PostInstallIntentListener listener, String packageName, DeviceManager deviceManager);
 
-    void reportOrder(ButtonRepository buttonRepository, DeviceManager deviceManager, Order order,
-            @Nullable OrderListener orderListener);
+    void reportOrder(ButtonRepository buttonRepository, DeviceManager deviceManager,
+            Features features, Order order, @Nullable OrderListener orderListener);
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -32,6 +32,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import com.usebutton.merchant.exception.ApplicationIdNotFoundException;
+import com.usebutton.merchant.module.Features;
 
 import java.util.ArrayList;
 import java.util.concurrent.Executor;
@@ -227,7 +228,7 @@ final class ButtonInternalImpl implements ButtonInternal {
 
     @Override
     public void reportOrder(ButtonRepository buttonRepository, DeviceManager deviceManager,
-            Order order, @Nullable final OrderListener orderListener) {
+            Features features, Order order, @Nullable final OrderListener orderListener) {
 
         if (buttonRepository.getApplicationId() == null) {
             executor.execute(new Runnable() {
@@ -241,7 +242,7 @@ final class ButtonInternalImpl implements ButtonInternal {
             return;
         }
 
-       buttonRepository.postOrder(order, deviceManager, new Task.Listener() {
+       buttonRepository.postOrder(order, deviceManager, features, new Task.Listener() {
            @Override
            public void onTaskComplete(@Nullable Object object) {
                 if (orderListener != null) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -100,8 +100,8 @@ public final class ButtonMerchant {
      */
     public static void reportOrder(@NonNull Context context, @NonNull Order order,
             @Nullable OrderListener orderListener) {
-        buttonInternal.reportOrder(getButtonRepository(context), getDeviceManager(context), order,
-                orderListener);
+        buttonInternal.reportOrder(getButtonRepository(context), getDeviceManager(context),
+                FeaturesImpl.getInstance(), order, orderListener);
     }
 
     /**

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
@@ -27,6 +27,8 @@ package com.usebutton.merchant;
 
 import android.support.annotation.Nullable;
 
+import com.usebutton.merchant.module.Features;
+
 /**
  * Internal data layer interface.
  */
@@ -52,5 +54,6 @@ interface ButtonRepository {
 
     void updateCheckDeferredDeepLink(boolean checkedDeferredDeepLink);
 
-    void postOrder(Order order, DeviceManager deviceManager, Task.Listener listener);
+    void postOrder(Order order, DeviceManager deviceManager, Features features,
+                Task.Listener listener);
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -28,6 +28,8 @@ package com.usebutton.merchant;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import com.usebutton.merchant.module.Features;
+
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -117,9 +119,10 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     }
 
     @Override
-    public void postOrder(Order order, DeviceManager deviceManager, Task.Listener listener) {
+    public void postOrder(Order order, DeviceManager deviceManager, Features features,
+            Task.Listener listener) {
         executorService.submit(
                 new PostOrderTask(listener, buttonApi, order, getApplicationId(),
-                        getSourceToken(), deviceManager, new ThreadManager()));
+                        getSourceToken(), deviceManager, features, new ThreadManager()));
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/DeviceManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/DeviceManager.java
@@ -39,12 +39,6 @@ interface DeviceManager {
     @Nullable
     String getAdvertisingId();
 
-    /**
-     * @return true is ad tracking is limited
-     */
-    @WorkerThread
-    boolean isLimitAdTrackingEnabled();
-
     Map<String, String> getSignals();
 
     String getTimeStamp();

--- a/button-merchant/src/main/java/com/usebutton/merchant/DeviceManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/DeviceManagerImpl.java
@@ -95,7 +95,8 @@ final class DeviceManagerImpl implements DeviceManager {
     @Override
     public String getAdvertisingId() {
         try {
-            return AdvertisingIdClient.getAdvertisingIdInfo(context).getId();
+            return isLimitAdTrackingEnabled() ? null
+                    : AdvertisingIdClient.getAdvertisingIdInfo(context).getId();
         } catch (IOException e) {
             Log.e(TAG, "Error has occurred", e);
         } catch (GooglePlayServicesNotAvailableException e) {
@@ -105,24 +106,6 @@ final class DeviceManagerImpl implements DeviceManager {
         }
 
         return null;
-    }
-
-    @WorkerThread
-    @Override
-    public boolean isLimitAdTrackingEnabled() {
-        try {
-            return AdvertisingIdClient.getAdvertisingIdInfo(context).isLimitAdTrackingEnabled();
-        } catch (IOException e) {
-            Log.e(TAG, "Error has occurred", e);
-        } catch (GooglePlayServicesNotAvailableException e) {
-            Log.e(TAG, "Error has occurred", e);
-        } catch (GooglePlayServicesRepairableException e) {
-            Log.e(TAG, "Error has occurred", e);
-        } catch (IllegalStateException e) {
-            Log.e(TAG, "Error has occurred", e);
-        }
-
-        return false;
     }
 
     @VisibleForTesting
@@ -211,6 +194,16 @@ final class DeviceManagerImpl implements DeviceManager {
                 .append(')');
 
         return sb.toString();
+    }
+
+    /**
+     * @return true is ad tracking is limited
+     */
+    @WorkerThread
+    private boolean isLimitAdTrackingEnabled()
+            throws GooglePlayServicesNotAvailableException, IOException,
+            GooglePlayServicesRepairableException {
+        return AdvertisingIdClient.getAdvertisingIdInfo(context).isLimitAdTrackingEnabled();
     }
 
     private String getSdkVersionName() {

--- a/button-merchant/src/main/java/com/usebutton/merchant/FeaturesImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/FeaturesImpl.java
@@ -54,8 +54,8 @@ final class FeaturesImpl implements Features {
         this.includesIfa = includesIfa;
     }
 
-    public boolean includesIfa() {
+    @Override
+    public boolean getIncludesIfa() {
         return includesIfa;
     }
-
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/GetPendingLinkTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/GetPendingLinkTask.java
@@ -49,6 +49,6 @@ final class GetPendingLinkTask extends Task<PostInstallLink> {
     @Override
     PostInstallLink execute() throws Exception {
         return buttonApi.getPendingLink(applicationId, deviceManager.getAdvertisingId(),
-                deviceManager.isLimitAdTrackingEnabled(), deviceManager.getSignals());
+                deviceManager.getSignals());
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/PostOrderTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/PostOrderTask.java
@@ -31,6 +31,7 @@ import android.support.annotation.VisibleForTesting;
 import com.usebutton.merchant.exception.ButtonNetworkException;
 import com.usebutton.merchant.exception.HttpStatusException;
 import com.usebutton.merchant.exception.NetworkNotFoundException;
+import com.usebutton.merchant.module.Features;
 
 /**
  * Asynchronous task used to report order to the Button API.
@@ -42,6 +43,7 @@ class PostOrderTask extends Task {
     private final String sourceToken;
     private final Order order;
     private final DeviceManager deviceManager;
+    private final Features features;
     private final ThreadManager threadManager;
 
     @VisibleForTesting
@@ -51,22 +53,21 @@ class PostOrderTask extends Task {
 
     PostOrderTask(@Nullable Listener listener, ButtonApi buttonApi, Order order,
             String applicationId, String sourceToken, DeviceManager deviceManager,
-            ThreadManager threadManager) {
+            Features features, ThreadManager threadManager) {
         super(listener);
         this.buttonApi = buttonApi;
         this.order = order;
         this.applicationId = applicationId;
         this.sourceToken = sourceToken;
         this.deviceManager = deviceManager;
+        this.features = features;
         this.threadManager = threadManager;
     }
 
     @Nullable
     @Override
     Void execute() throws Exception {
-        String advertisingId = deviceManager.isLimitAdTrackingEnabled()
-                ? null : deviceManager.getAdvertisingId();
-
+        String advertisingId = features.getIncludesIfa() ? deviceManager.getAdvertisingId() : null;
         // loop and execute postOrder until max retries is met or non case exception is met
         while (true) {
             try {

--- a/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/module/Features.java
@@ -32,4 +32,5 @@ public interface Features {
 
     void setIncludesIfa(boolean includesIfa);
 
+    boolean getIncludesIfa();
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -72,7 +72,7 @@ public class ButtonApiImplTest {
 
         PostInstallLink postInstallLink =
                 buttonApi.getPendingLink("valid_application_id", "valid_ifa",
-                        true, Collections.<String, String>emptyMap());
+                        Collections.<String, String>emptyMap());
 
         assertNotNull(postInstallLink);
         assertEquals(true, postInstallLink.isMatch());
@@ -92,7 +92,7 @@ public class ButtonApiImplTest {
                 .thenReturn(response);
 
         buttonApi.getPendingLink("valid_application_id", "valid_ifa",
-                true, Collections.singletonMap("key", "value"));
+                Collections.singletonMap("key", "value"));
 
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject body = apiRequest.getBody();
@@ -104,7 +104,6 @@ public class ButtonApiImplTest {
         // request body
         assertEquals("valid_application_id", body.getString("application_id"));
         assertEquals("valid_ifa", body.getString("ifa"));
-        assertEquals(true, body.getBoolean("ifa_limited"));
         assertEquals("value", signals.getString("key"));
     }
 
@@ -114,7 +113,7 @@ public class ButtonApiImplTest {
         when(response.getBody()).thenThrow(JSONException.class);
         when(connectionManager.executeRequest(any(ApiRequest.class))).thenReturn(response);
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa", true,
+        buttonApi.getPendingLink("valid_application_id", "valid_ifa",
                 Collections.<String, String>emptyMap());
     }
 
@@ -123,7 +122,7 @@ public class ButtonApiImplTest {
         when(connectionManager.executeRequest(any(ApiRequest.class)))
                 .thenThrow(ButtonNetworkException.class);
 
-        buttonApi.getPendingLink("valid_application_id", "valid_ifa", true,
+        buttonApi.getPendingLink("valid_application_id", "valid_ifa",
                 Collections.<String, String>emptyMap());
     }
 

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -210,9 +210,10 @@ public class ButtonApiImplTest {
                 .build();
 
         String sourceToken = "valid_source_token";
+        String advertisingId = "valid_advertising_id";
 
         buttonApi.postOrder(order, "valid_application_id",
-                sourceToken, "valid_advertising_id");
+                sourceToken, advertisingId);
 
         ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
@@ -225,6 +226,7 @@ public class ButtonApiImplTest {
         assertEquals(ButtonUtil.formatDate(purchaseDate),
                 requestBody.getString("purchase_date"));
         assertEquals(customerOrderId, requestBody.getString("customer_order_id"));
+        assertEquals(advertisingId, requestBody.getString("advertising_id"));
 
         assertNull(requestBody.optJSONArray("line_items"));
         assertNull(requestBody.optJSONObject("customer"));
@@ -297,10 +299,8 @@ public class ButtonApiImplTest {
                 .setCustomer(customer)
                 .build();
 
-        String advertisingId = "valid_advertising_id";
-
         buttonApi.postOrder(order, "valid_application_id",
-                "valid_source_token", advertisingId);
+                "valid_source_token", "valid_advertising_id");
 
         ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
@@ -310,7 +310,6 @@ public class ButtonApiImplTest {
         JSONObject customerJson = requestBody.getJSONObject("customer");
         assertEquals(customerId, customerJson.getString("id"));
         assertEquals(customerEmail, customerJson.getString("email_sha256"));
-        assertEquals(advertisingId, customerJson.getString("device_id"));
     }
 
     @Test(expected = ButtonNetworkException.class)

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -31,6 +31,7 @@ import android.support.annotation.NonNull;
 
 import com.usebutton.merchant.exception.ApplicationIdNotFoundException;
 import com.usebutton.merchant.exception.ButtonNetworkException;
+import com.usebutton.merchant.module.Features;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -434,7 +435,8 @@ public class ButtonInternalImplTest {
         when(buttonRepository.getApplicationId()).thenReturn(null);
         OrderListener orderListener = mock(OrderListener.class);
 
-        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class), orderListener);
+        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class),
+               mock(Features.class), mock(Order.class), orderListener);
 
         verify(orderListener).onResult(any(ApplicationIdNotFoundException.class));
     }
@@ -444,12 +446,14 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
         Order order = mock(Order.class);
         OrderListener orderListener = mock(OrderListener.class);
 
-        buttonInternal.reportOrder(buttonRepository, deviceManager, order, orderListener);
+        buttonInternal.reportOrder(buttonRepository, deviceManager, features, order, orderListener);
 
-        verify(buttonRepository).postOrder(eq(order), eq(deviceManager), any(Task.Listener.class));
+        verify(buttonRepository).postOrder(eq(order), eq(deviceManager), eq(features),
+                any(Task.Listener.class));
     }
 
     @Test
@@ -458,12 +462,12 @@ public class ButtonInternalImplTest {
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         OrderListener orderListener = mock(OrderListener.class);
 
-        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class),
-                orderListener);
+        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), mock(Order.class), orderListener);
 
         ArgumentCaptor<Task.Listener> argumentCaptor = ArgumentCaptor.forClass(Task.Listener.class);
         verify(buttonRepository).postOrder(any(Order.class), any(DeviceManager.class),
-                argumentCaptor.capture());
+                any(Features.class), argumentCaptor.capture());
         argumentCaptor.getValue().onTaskComplete(null);
         verify(orderListener).onResult((Throwable) isNull());
     }
@@ -474,12 +478,12 @@ public class ButtonInternalImplTest {
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         OrderListener orderListener = mock(OrderListener.class);
 
-        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class), mock(Order.class),
-                orderListener);
+        buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), mock(Order.class), orderListener);
 
         ArgumentCaptor<Task.Listener> argumentCaptor = ArgumentCaptor.forClass(Task.Listener.class);
         verify(buttonRepository).postOrder(any(Order.class), any(DeviceManager.class),
-                argumentCaptor.capture());
+                any(Features.class), argumentCaptor.capture());
         Exception exception = mock(Exception.class);
         argumentCaptor.getValue().onTaskError(exception);
         verify(orderListener).onResult(exception);

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -32,6 +32,8 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.util.DisplayMetrics;
 
+import com.usebutton.merchant.module.Features;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -148,7 +150,7 @@ public class ButtonMerchantTest {
         ButtonMerchant.reportOrder(context, order, orderListener);
 
         verify(buttonInternal).reportOrder(any(ButtonRepository.class), any(DeviceManager.class),
-                eq(order), eq(orderListener));
+                any(Features.class), eq(order), eq(orderListener));
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
@@ -25,6 +25,8 @@
 
 package com.usebutton.merchant;
 
+import com.usebutton.merchant.module.Features;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -122,7 +124,7 @@ public class ButtonRepositoryImplTest {
     @Test
     public void postOrder_executeTask() {
         buttonRepository.postOrder(mock(Order.class), mock(DeviceManager.class),
-                mock(Task.Listener.class));
+                mock(Features.class), mock(Task.Listener.class));
 
         verify(executorService).submit(any(PostOrderTask.class));
     }

--- a/button-merchant/src/test/java/com/usebutton/merchant/FeaturesImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/FeaturesImplTest.java
@@ -44,11 +44,11 @@ public class FeaturesImplTest {
     public void setIncludesIfa_verifyIncludesIfa() {
         features.setIncludesIfa(false);
 
-        assertFalse(features.includesIfa());
+        assertFalse(features.getIncludesIfa());
     }
 
     @Test
-    public void includesIfa_verifyDefaultValue() {
-        assertTrue(features.includesIfa());
+    public void getIncludesIfa_verifyDefaultValue() {
+        assertTrue(features.getIncludesIfa());
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/GetPendingLinkTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/GetPendingLinkTaskTest.java
@@ -66,13 +66,11 @@ public class GetPendingLinkTaskTest {
 
         when(deviceManager.getAdvertisingId()).thenReturn("valid_ifa");
         when(deviceManager.getSignals()).thenReturn(signalsMap);
-        when(deviceManager.isLimitAdTrackingEnabled()).thenReturn(true);
 
-        when(buttonApi.getPendingLink(applicationId, "valid_ifa", true, signalsMap)).thenReturn(
-                postInstallLink);
+        when(buttonApi.getPendingLink(applicationId, "valid_ifa", signalsMap))
+                .thenReturn(postInstallLink);
 
         assertEquals(postInstallLink, task.execute());
-        verify(buttonApi).getPendingLink(applicationId, "valid_ifa",
-                true, signalsMap);
+        verify(buttonApi).getPendingLink(applicationId, "valid_ifa", signalsMap);
     }
 }


### PR DESCRIPTION
### Goals :soccer:
* Feature flag `includesIfa` can be set false to no longer include ifa within the order reporting request

### Implementation :construction:
* Added `Features` to `PostOrderTask` and check feature flag to whether or not include ifa
* Changed `isLimitAdTrackingEnabled` to a private method to be used within the `DeviceManagerImpl` class

### Testing :mag:
* Updated tests