### PR TITLE
Updated including ifa in post install request to use features flag

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
@@ -57,8 +57,8 @@ interface ButtonInternal {
 
     void clearAllData(ButtonRepository buttonRepository);
 
-    void handlePostInstallIntent(ButtonRepository buttonRepository,
-            PostInstallIntentListener listener, String packageName, DeviceManager deviceManager);
+    void handlePostInstallIntent(ButtonRepository buttonRepository, DeviceManager deviceManager,
+            Features features, String packageName, PostInstallIntentListener listener);
 
     void reportOrder(ButtonRepository buttonRepository, DeviceManager deviceManager,
             Features features, Order order, @Nullable OrderListener orderListener);

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -173,8 +173,9 @@ public final class ButtonMerchant {
      */
     public static void handlePostInstallIntent(@NonNull Context context, @NonNull
             PostInstallIntentListener listener) {
-        buttonInternal.handlePostInstallIntent(getButtonRepository(context), listener,
-                context.getPackageName(), getDeviceManager(context));
+        buttonInternal.handlePostInstallIntent(getButtonRepository(context),
+                getDeviceManager(context), FeaturesImpl.getInstance(),
+                context.getPackageName(), listener);
     }
 
     /**

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
@@ -46,9 +46,10 @@ interface ButtonRepository {
 
     void clear();
 
-    void getPendingLink(Task.Listener<PostInstallLink> listener, DeviceManager deviceManager);
+    void getPendingLink(DeviceManager deviceManager, Features features,
+            Task.Listener<PostInstallLink> listener);
 
-    void postUserActivity(DeviceManager manager, Order order, Task.Listener listener);
+    void postUserActivity(DeviceManager deviceManager, Order order, Task.Listener listener);
 
     boolean checkedDeferredDeepLink();
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -92,11 +92,11 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     }
 
     @Override
-    public void getPendingLink(Task.Listener<PostInstallLink> listener,
-            DeviceManager deviceManager) {
+    public void getPendingLink(DeviceManager deviceManager, Features features,
+            Task.Listener<PostInstallLink> listener) {
         GetPendingLinkTask getPendingLinkTask =
-                new GetPendingLinkTask(listener, buttonApi, getApplicationId(),
-                        deviceManager);
+                new GetPendingLinkTask(buttonApi, deviceManager, features, getApplicationId(),
+                        listener);
 
         executorService.submit(getPendingLinkTask);
     }

--- a/button-merchant/src/main/java/com/usebutton/merchant/GetPendingLinkTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/GetPendingLinkTask.java
@@ -27,6 +27,8 @@ package com.usebutton.merchant;
 
 import android.support.annotation.Nullable;
 
+import com.usebutton.merchant.module.Features;
+
 /**
  * Class handles getting the pending link from the backend when a user is going from web to native
  * mobile.
@@ -34,21 +36,23 @@ import android.support.annotation.Nullable;
 final class GetPendingLinkTask extends Task<PostInstallLink> {
 
     private final ButtonApi buttonApi;
-    private final String applicationId;
     private final DeviceManager deviceManager;
+    private final Features features;
+    private final String applicationId;
 
-    GetPendingLinkTask(Listener<PostInstallLink> listener, ButtonApi buttonApi,
-            String applicationId, DeviceManager deviceManager) {
+    GetPendingLinkTask(ButtonApi buttonApi, DeviceManager deviceManager, Features features,
+            String applicationId, Listener<PostInstallLink> listener) {
         super(listener);
         this.buttonApi = buttonApi;
-        this.applicationId = applicationId;
         this.deviceManager = deviceManager;
+        this.features = features;
+        this.applicationId = applicationId;
     }
 
     @Nullable
     @Override
     PostInstallLink execute() throws Exception {
-        return buttonApi.getPendingLink(applicationId, deviceManager.getAdvertisingId(),
-                deviceManager.getSignals());
+        String advertisingId = features.getIncludesIfa() ? deviceManager.getAdvertisingId() : null;
+        return buttonApi.getPendingLink(applicationId, advertisingId, deviceManager.getSignals());
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -283,17 +283,17 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager,
+                features,"com.usebutton.merchant", postInstallIntentListener);
 
         ArgumentCaptor<GetPendingLinkTask.Listener> listenerArgumentCaptor =
                 ArgumentCaptor.forClass(GetPendingLinkTask.Listener.class);
-        verify(buttonRepository).getPendingLink(listenerArgumentCaptor.capture(),
-                eq(deviceManager));
+        verify(buttonRepository).getPendingLink(eq(deviceManager), eq(features),
+                listenerArgumentCaptor.capture());
 
         PostInstallLink.Attribution attribution =
                 new PostInstallLink.Attribution("valid_source_token", "SMS");
@@ -312,17 +312,17 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager,
+                features, "com.usebutton.merchant", postInstallIntentListener);
 
         ArgumentCaptor<GetPendingLinkTask.Listener> listenerArgumentCaptor =
                 ArgumentCaptor.forClass(GetPendingLinkTask.Listener.class);
-        verify(buttonRepository).getPendingLink(listenerArgumentCaptor.capture(),
-                eq(deviceManager));
+        verify(buttonRepository).getPendingLink(eq(deviceManager), eq(features),
+                listenerArgumentCaptor.capture());
 
         PostInstallLink postInstallLink =
                 new PostInstallLink(false, "ddl-6faffd3451edefd3", null, null);
@@ -338,15 +338,15 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn(null);
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager, features,
+                "com.usebutton.merchant", postInstallIntentListener);
 
-        verify(buttonRepository, never()).getPendingLink(any(Task.Listener.class),
-                any(DeviceManager.class));
+        verify(buttonRepository, never()).getPendingLink(any(DeviceManager.class),
+                any(Features.class), any(Task.Listener.class));
         verify(buttonRepository, never()).setSourceToken(anyString());
         verify(postInstallIntentListener).onResult((Intent) isNull(),
                 any(ApplicationIdNotFoundException.class));
@@ -357,17 +357,17 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager,
+                features, "com.usebutton.merchant", postInstallIntentListener);
 
         ArgumentCaptor<GetPendingLinkTask.Listener> listenerArgumentCaptor =
                 ArgumentCaptor.forClass(GetPendingLinkTask.Listener.class);
-        verify(buttonRepository).getPendingLink(listenerArgumentCaptor.capture(),
-                eq(deviceManager));
+        verify(buttonRepository).getPendingLink(eq(deviceManager), eq(features),
+                listenerArgumentCaptor.capture());
 
         listenerArgumentCaptor.getValue().onTaskError(new ButtonNetworkException(""));
 
@@ -380,17 +380,18 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         when(deviceManager.isOldInstallation()).thenReturn(false);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(false);
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager, features,
+                "com.usebutton.merchant", postInstallIntentListener);
 
         verify(buttonRepository).updateCheckDeferredDeepLink(true);
-        verify(buttonRepository).getPendingLink(any(Task.Listener.class), any(DeviceManager.class));
+        verify(buttonRepository).getPendingLink(any(DeviceManager.class), any(Features.class),
+                any(Task.Listener.class));
     }
 
     @Test
@@ -398,14 +399,14 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         when(deviceManager.isOldInstallation()).thenReturn(true);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(false);
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager, features,
+                "com.usebutton.merchant", postInstallIntentListener);
 
         verify(postInstallIntentListener).onResult(null, null);
         verify(buttonRepository, never()).updateCheckDeferredDeepLink(anyBoolean());
@@ -416,14 +417,14 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
         DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
 
         when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
         when(deviceManager.isOldInstallation()).thenReturn(false);
         when(buttonRepository.checkedDeferredDeepLink()).thenReturn(true);
 
-        buttonInternal.handlePostInstallIntent(buttonRepository, postInstallIntentListener,
-                "com.usebutton.merchant",
-                deviceManager);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager, features,
+                "com.usebutton.merchant", postInstallIntentListener);
 
         verify(postInstallIntentListener).onResult((Intent) isNull(), (Throwable) isNull());
         verify(buttonRepository, never()).updateCheckDeferredDeepLink(anyBoolean());

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -133,13 +133,15 @@ public class ButtonMerchantTest {
 
     @Test
     public void handlePostInstallIntent_verifyButtonInternal() {
-        when(context.getPackageName()).thenReturn("com.usebutton.merchant");
+        String packageName = "com.usebutton.merchant";
+        when(context.getPackageName()).thenReturn(packageName);
         PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
 
         ButtonMerchant.handlePostInstallIntent(context, postInstallIntentListener);
 
-        verify(buttonInternal).handlePostInstallIntent(any(ButtonRepository.class), eq(
-                postInstallIntentListener), anyString(), any(DeviceManager.class));
+        verify(buttonInternal).handlePostInstallIntent(any(ButtonRepository.class),
+                any(DeviceManager.class), any(Features.class), eq(packageName),
+                eq(postInstallIntentListener));
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
@@ -94,7 +94,8 @@ public class ButtonRepositoryImplTest {
 
     @Test
     public void getPendingLink_executeTask() {
-        buttonRepository.getPendingLink(mock(GetPendingLinkTask.Listener.class), null);
+        buttonRepository.getPendingLink(mock(DeviceManager.class), mock(Features.class),
+                mock(GetPendingLinkTask.Listener.class));
 
         verify(executorService).submit(any(GetPendingLinkTask.class));
     }


### PR DESCRIPTION
### Goals :soccer:
* Feature flag `includesIfa` can be set false to no longer include ifa within the post install request

### Implementation :construction:
* Added `Features` to `GetPendingLinkTask` and check feature flag to whether or not include ifa

### Testing :mag:
* Updated tests