### PR TITLE
Allow orders to report multiple line items

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -152,8 +152,9 @@ final class ButtonApiImpl implements ButtonApi {
             requestBody.put("customer_order_id", order.getCustomerOrderId());
             requestBody.put("advertising_id", advertisingId);
 
+            JSONArray lineItemsJson = new JSONArray();
+
             for (Order.LineItem lineItem : order.getLineItems()) {
-                JSONArray lineItemsJson = new JSONArray();
                 JSONObject lineItemJson = new JSONObject();
 
                 List<String> lineItemCategory = lineItem.getCategory();
@@ -185,8 +186,9 @@ final class ButtonApiImpl implements ButtonApi {
                 lineItemJson.put("sku", lineItem.getSku());
 
                 lineItemsJson.put(lineItemJson);
-                requestBody.put("line_items", lineItemsJson);
             }
+
+            requestBody.put("line_items", lineItemsJson);
 
             Order.Customer customer = order.getCustomer();
             if (customer != null) {


### PR DESCRIPTION
### Issue Link :link:
Fix to allow reporting multiple line items 

### Implementation :construction:
Moved the line items json creation outside of the line item iteration 

### Testing :mag:
Added test verifying multiple line items added
