### PR TITLE
Un-deprecate trackOrder and remove top-level amount field

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -84,7 +84,6 @@ public final class ButtonMerchant {
      * @deprecated This method is deprecated and will be removed in a future version.
      * It is safe to remove your usage of this method.
      */
-    @Deprecated
     public static void trackOrder(@NonNull Context context, @NonNull Order order,
             @Nullable UserActivityListener userActivityListener) {
         buttonInternal.trackOrder(getButtonRepository(context), getDeviceManager(context), order,

--- a/button-merchant/src/main/java/com/usebutton/merchant/Order.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/Order.java
@@ -39,7 +39,6 @@ import java.util.Map;
 public class Order {
 
     private String id;
-    @Deprecated
     private long amount;
     private String currencyCode;
     private Date purchaseDate;
@@ -68,7 +67,6 @@ public class Order {
         return id;
     }
 
-    @Deprecated
     public long getAmount() {
         return amount;
     }
@@ -101,7 +99,6 @@ public class Order {
     public static class Builder {
 
         private String id;
-        @Deprecated
         private long amount = 0;
         private String currencyCode = "USD";
         private Date purchaseDate;
@@ -143,7 +140,6 @@ public class Order {
          *
          * @deprecated This field is no longer supported and will be removed in a future release.
          */
-        @Deprecated
         public Builder setAmount(long amount) {
             this.amount = amount;
             return this;


### PR DESCRIPTION
### Goals :soccer:
- Un-deprecate `trackOrder()` method and `amount` field
