### PR TITLE
Include `source` in `signals`

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/DeviceManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/DeviceManagerImpl.java
@@ -130,6 +130,7 @@ final class DeviceManagerImpl implements DeviceManager {
         signalsMap.put("os_version", Build.VERSION.RELEASE);
         signalsMap.put("device", String.format("%s %s", Build.MANUFACTURER, Build.MODEL));
         signalsMap.put("screen", getScreenSize());
+        signalsMap.put("source", "button-merchant");
         final Locale locale = Locale.getDefault();
         signalsMap.put("country", locale.getCountry());
         signalsMap.put("language", locale.getLanguage());

--- a/button-merchant/src/test/java/com/usebutton/merchant/DeviceManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/DeviceManagerImplTest.java
@@ -110,6 +110,7 @@ public class DeviceManagerImplTest {
         assertTrue(signals.containsKey("screen"));
         assertTrue(signals.containsKey("country"));
         assertTrue(signals.containsKey("language"));
+        assertEquals("button-merchant", signals.get("source"));
     }
 
     @Test


### PR DESCRIPTION
### Goals :soccer:
Include `signals.source: button-merchant` in the `/v1/web/deferred-deeplink` request.

### Testing :mag:
Ran through a deferred deeplink test to ensure that the signal is parsed.