### PR TITLE
Update ISO-8601 string to be compatible with older versions of Java

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
@@ -43,7 +43,7 @@ final class ButtonUtil {
 
     private static final String TAG = ButtonUtil.class.getSimpleName();
 
-    private static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
 
     private static final SimpleDateFormat simpleDateFormat =
             new SimpleDateFormat(ISO_8601, Locale.US);


### PR DESCRIPTION
### Issue 🐛
Older Android APIs for `SimpleDateFormatter` use an outdate `java.text` class which does not support the character `X` in formatting strings. As a result, the thread would silently crash on API 19 and below.

### Implementation :construction:
The fix involves using a different formatting string which still adheres to ISO-8601 [as per RFC-3339](https://tools.ietf.org/html/rfc3339#section-5.8).

### Testing :mag:
Confirmed by reporting a test order that the date is parsed correctly by Button's servers.
