### PR TITLE
Refresh session ID from Button network requests; Include key fields to all requests

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -197,8 +197,8 @@ button#report-orders-to-buttons-order-api">Reporting Orders to Button</a>
 
         DeviceManager deviceManager = getDeviceManager(context);
 
-        ConnectionManager connectionManager =
-                ConnectionManagerImpl.getInstance(BASE_URL, deviceManager.getUserAgent());
+        ConnectionManager connectionManager = ConnectionManagerImpl.getInstance(BASE_URL,
+                deviceManager.getUserAgent(), persistenceManager);
 
         ButtonApi buttonApi = ButtonApiImpl.getInstance(connectionManager);
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -170,7 +170,7 @@ final class ConnectionManagerImpl implements ConnectionManager {
         if (responseBody == null) return;
 
         try {
-            JSONObject metaJson = responseBody.getJSONObject("object").getJSONObject("meta");
+            JSONObject metaJson = responseBody.getJSONObject("meta");
             if (metaJson.has("session_id")) {
                 String sessionId = metaJson.optString("session_id", null);
                 if (sessionId != null) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -101,7 +101,7 @@ final class ConnectionManagerImpl implements ConnectionManager {
             }
 
             JSONObject body = request.getBody();
-            body.put("session", persistenceManager.getSessionId());
+            body.put("session_id", persistenceManager.getSessionId());
             OutputStreamWriter writer =
                     new OutputStreamWriter(urlConnection.getOutputStream(), ENCODING);
             writer.write(body.toString());
@@ -171,8 +171,8 @@ final class ConnectionManagerImpl implements ConnectionManager {
 
         try {
             JSONObject metaJson = responseBody.getJSONObject("object").getJSONObject("meta");
-            if (metaJson.has("session")) {
-                String sessionId = metaJson.optString("session", null);
+            if (metaJson.has("session_id")) {
+                String sessionId = metaJson.optString("session_id", null);
                 if (sessionId != null) {
                     persistenceManager.setSessionId(sessionId);
                 } else {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -101,6 +101,7 @@ final class ConnectionManagerImpl implements ConnectionManager {
             }
 
             JSONObject body = request.getBody();
+            body.put("session", persistenceManager.getSessionId());
             OutputStreamWriter writer =
                     new OutputStreamWriter(urlConnection.getOutputStream(), ENCODING);
             writer.write(body.toString());

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -26,6 +26,7 @@
 package com.usebutton.merchant;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
@@ -66,19 +67,22 @@ final class ConnectionManagerImpl implements ConnectionManager {
 
     private final String baseUrl;
     private final String userAgent;
+    private final PersistenceManager persistenceManager;
 
-    static ConnectionManager getInstance(String baseUrl, String userAgent) {
+    static ConnectionManager getInstance(String baseUrl, String userAgent,
+            PersistenceManager persistenceManager) {
         if (instance == null) {
-            instance = new ConnectionManagerImpl(baseUrl, userAgent);
+            instance = new ConnectionManagerImpl(baseUrl, userAgent, persistenceManager);
         }
 
         return instance;
     }
 
     @VisibleForTesting
-    ConnectionManagerImpl(String baseUrl, String userAgent) {
+    ConnectionManagerImpl(String baseUrl, String userAgent, PersistenceManager persistenceManager) {
         this.baseUrl = baseUrl;
         this.userAgent = userAgent;
+        this.persistenceManager = persistenceManager;
     }
 
     @Override
@@ -113,6 +117,7 @@ final class ConnectionManagerImpl implements ConnectionManager {
             }
 
             JSONObject responseJson = readResponseBody(urlConnection);
+            refreshSessionIfAvailable(responseJson);
             return new NetworkResponse(responseCode, responseJson);
         } catch (IOException e) {
             Log.e(TAG, "Error has occurred", e);
@@ -152,5 +157,29 @@ final class ConnectionManagerImpl implements ConnectionManager {
         }
         reader.close();
         return new JSONObject(response.toString());
+    }
+
+    /**
+     * Refreshes the current session if provided in the network response.
+     * If a null session is provided, the Library data is cleared.
+     *
+     * @param responseBody the JSON body of the network response
+     */
+    private void refreshSessionIfAvailable(@Nullable JSONObject responseBody) {
+        if (responseBody == null) return;
+
+        try {
+            JSONObject metaJson = responseBody.getJSONObject("object").getJSONObject("meta");
+            if (metaJson.has("session")) {
+                String sessionId = metaJson.optString("session", null);
+                if (sessionId != null) {
+                    persistenceManager.setSessionId(sessionId);
+                } else {
+                    persistenceManager.clear();
+                }
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Error parsing session data from response body", e);
+        }
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/PersistenceManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/PersistenceManager.java
@@ -31,6 +31,12 @@ import android.support.annotation.Nullable;
  * Internal interface for storage layer.
  */
 interface PersistenceManager {
+
+    void setSessionId(String sessionId);
+
+    @Nullable
+    String getSessionId();
+
     void setSourceToken(String sourceToken);
 
     @Nullable

--- a/button-merchant/src/main/java/com/usebutton/merchant/PersistenceManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/PersistenceManagerImpl.java
@@ -55,6 +55,17 @@ final class PersistenceManagerImpl implements PersistenceManager {
     }
 
     @Override
+    public void setSessionId(String sessionId) {
+        sharedPreferences.edit().putString(Key.SESSION_ID, sessionId).apply();
+    }
+
+    @Nullable
+    @Override
+    public String getSessionId() {
+        return sharedPreferences.getString(Key.SESSION_ID, null);
+    }
+
+    @Override
     public void setSourceToken(String sourceToken) {
         sharedPreferences.edit().putString(Key.SOURCE_TOKEN, sourceToken).apply();
     }
@@ -84,9 +95,11 @@ final class PersistenceManagerImpl implements PersistenceManager {
     /**
      * Class contains all of the keys for the shared preferences
      */
-    final class Key {
+    static final class Key {
 
         private static final String PREFIX = "btn_";
+
+        static final String SESSION_ID = PREFIX + "session_id";
 
         static final String SOURCE_TOKEN = PREFIX + "source_token";
 

--- a/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
@@ -195,7 +195,7 @@ public class ConnectionManagerImplTest {
         String sessionId = "sess-abc1234567890";
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
-                .setBody("{\"object\":{\"meta\":{\"session\":\"" + sessionId + "\"}}}")
+                .setBody("{\"object\":{\"meta\":{\"session_id\":\"" + sessionId + "\"}}}")
         );
 
         connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
@@ -226,7 +226,7 @@ public class ConnectionManagerImplTest {
     public void executeRequest_nullSession_shouldClearData() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
-                .setBody("{\"object\":{\"meta\":{\"session\": null }}}")
+                .setBody("{\"object\":{\"meta\":{\"session_id\": null }}}")
         );
 
         connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
@@ -250,6 +250,6 @@ public class ConnectionManagerImplTest {
 
         RecordedRequest recordedRequest = server.takeRequest();
         JSONObject request = new JSONObject(recordedRequest.getBody().readUtf8());
-        assertEquals(sessionId, request.getString("session"));
+        assertEquals(sessionId, request.getString("session_id"));
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
@@ -195,7 +195,7 @@ public class ConnectionManagerImplTest {
         String sessionId = "sess-abc1234567890";
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
-                .setBody("{\"object\":{\"meta\":{\"session_id\":\"" + sessionId + "\"}}}")
+                .setBody("{\"meta\":{\"session_id\":\"" + sessionId + "\"}}")
         );
 
         connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
@@ -210,7 +210,7 @@ public class ConnectionManagerImplTest {
     public void executeRequest_unavailableSession_shouldPersistPreviousSession() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
-                .setBody("{\"object\":{\"meta\":{}}}")
+                .setBody("{\"meta\":{}}")
         );
 
         connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
@@ -226,7 +226,7 @@ public class ConnectionManagerImplTest {
     public void executeRequest_nullSession_shouldClearData() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
-                .setBody("{\"object\":{\"meta\":{\"session_id\": null }}}")
+                .setBody("{\"meta\":{\"session_id\": null }}")
         );
 
         connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,

--- a/button-merchant/src/test/java/com/usebutton/merchant/PersistenceManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/PersistenceManagerImplTest.java
@@ -65,6 +65,21 @@ public class PersistenceManagerImplTest {
     }
 
     @Test
+    public void setSessionId_persistToSharedPrefs() {
+        persistenceManager.setSessionId("valid_session_id");
+        verify(editor).putString(PersistenceManagerImpl.Key.SESSION_ID, "valid_session_id");
+        verify(editor).apply();
+    }
+
+    @Test
+    public void getSessionId_returnValidSessionId() {
+        when(sharedPreferences.getString(PersistenceManagerImpl.Key.SESSION_ID, null))
+                .thenReturn("valid_session_id");
+        String sessionId = persistenceManager.getSessionId();
+        assertEquals("valid_session_id", sessionId);
+    }
+
+    @Test
     public void setSourceToken_persistToSharedPrefs() {
         persistenceManager.setSourceToken("valid_source_token");
         verify(editor).putString(PersistenceManagerImpl.Key.SOURCE_TOKEN, "valid_source_token");


### PR DESCRIPTION
### Goals :soccer:
Add the ability to refresh the session whenever a request is made to the Button servers. Additionally, we now include the `session_id` in requests.

### Implementation :construction:
All network requests are made by the `ConnectionManager`. I have modified this class so that it has the ability to persist data to the disk via the `PersistenceManager`. All Button network request responses will soon include information about the current-most valid session. The valid JSON for which is as follow:
```
{
    "meta": {
      "session_id": "some-session-string"
    },
   "object": { ... }
}
```
If the `meta.session_id` string is available, the session ID is persisted to disk.
If the `meta.session_id` string is unavailable, no change occurs.
If the `meta.session_id` string is `null`, the Library's persisted data is cleared.

