### PR TITLE
Include `application_id` in all requests

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
@@ -37,6 +37,8 @@ import java.util.Map;
  */
 interface ButtonApi {
 
+    void setApplicationId(String applicationId);
+
     @Nullable
     @WorkerThread
     PostInstallLink getPendingLink(String applicationId, @Nullable String advertisingId,

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -62,6 +62,11 @@ final class ButtonApiImpl implements ButtonApi {
         this.connectionManager = connectionManager;
     }
 
+    @Override
+    public void setApplicationId(String applicationId) {
+        connectionManager.setApplicationId(applicationId);
+    }
+
     @Nullable
     @WorkerThread
     @Override

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -67,6 +67,7 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     @Override
     public void setApplicationId(String applicationId) {
         this.applicationId = applicationId;
+        buttonApi.setApplicationId(applicationId);
     }
 
     @Nullable

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManager.java
@@ -32,5 +32,7 @@ import com.usebutton.merchant.exception.ButtonNetworkException;
  */
 interface ConnectionManager {
 
+    void setApplicationId(String applicationId);
+
     NetworkResponse executeRequest(ApiRequest request) throws ButtonNetworkException;
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -65,6 +65,8 @@ final class ConnectionManagerImpl implements ConnectionManager {
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String ENCODING = "UTF-8";
 
+    private String applicationId;
+
     private final String baseUrl;
     private final String userAgent;
     private final PersistenceManager persistenceManager;
@@ -86,6 +88,11 @@ final class ConnectionManagerImpl implements ConnectionManager {
     }
 
     @Override
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    @Override
     public NetworkResponse executeRequest(@NonNull ApiRequest request)
             throws ButtonNetworkException {
         HttpURLConnection urlConnection = null;
@@ -101,9 +108,13 @@ final class ConnectionManagerImpl implements ConnectionManager {
             }
 
             JSONObject body = request.getBody();
+
+            // Append necessary information to each request
+            body.put("application_id", applicationId);
             body.put("session_id", persistenceManager.getSessionId());
-            OutputStreamWriter writer =
-                    new OutputStreamWriter(urlConnection.getOutputStream(), ENCODING);
+
+            OutputStreamWriter writer = new OutputStreamWriter(urlConnection.getOutputStream(),
+                    ENCODING);
             writer.write(body.toString());
             writer.close();
 

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -64,6 +64,13 @@ public class ButtonApiImplTest {
     }
 
     @Test
+    public void setApplicationId_shouldProvideToConnectionManager() {
+        buttonApi.setApplicationId("valid_application_id");
+
+        verify(connectionManager).setApplicationId("valid_application_id");
+    }
+
+    @Test
     public void getPendingLink_returnValidResponse_validatePostInstallLink() throws Exception {
         JSONObject body = new JSONObject(
                 "{\"meta\":{\"status\":\"ok\"},\"object\":{\"match\":true,\"id\":\"ddl-6faffd3451edefd3\",\"action\":\"uber://asdfasfasf\",\"attribution\":{\"btn_ref\":\"srctok-afsldkjf29askldfjwe\",\"utm_source\":\"SMS\"}}}");

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ButtonRepositoryImplTest {
@@ -60,9 +61,16 @@ public class ButtonRepositoryImplTest {
     }
 
     @Test
-    public void setApplicationId_persistToPersistenceManager() {
+    public void setApplicationId_cacheInMemory() {
         buttonRepository.setApplicationId("valid_application_id");
         assertEquals("valid_application_id", buttonRepository.getApplicationId());
+        verifyZeroInteractions(persistenceManager);
+    }
+
+    @Test
+    public void setApplicationId_provideToButtonApi() {
+        buttonRepository.setApplicationId("valid_application_id");
+        verify(buttonApi).setApplicationId("valid_application_id");
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ConnectionManagerImplTest.java
@@ -252,4 +252,20 @@ public class ConnectionManagerImplTest {
         JSONObject request = new JSONObject(recordedRequest.getBody().readUtf8());
         assertEquals(sessionId, request.getString("session_id"));
     }
+
+    @Test
+    public void executeRequest_shouldIncludeApplicationId() throws Exception {
+        String applicationId = "valid_application_id";
+        connectionManager.setApplicationId(applicationId);
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{}"));
+
+        connectionManager.executeRequest(new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
+                "/test")
+                .build()
+        );
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        JSONObject request = new JSONObject(recordedRequest.getBody().readUtf8());
+        assertEquals(applicationId, request.getString("application_id"));
+    }
 }


### PR DESCRIPTION
### Goals :soccer:
To include the `application_id` for the host application in all Button network requests.

### Implementation :construction:
This PR ensures that when `ButtonMerchant.configure(~)` is called, the application ID is provided to the `ConnectionManager`. This class then ensures that `application_id` is appended to the body of all requests.
N.B. this does **not** persist the app ID to disk.
