### PR TITLE
Report direct deeplink events

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -224,4 +224,33 @@ final class ButtonApiImpl implements ButtonApi {
 
         return null;
     }
+
+    @Nullable
+    @Override
+    public Void postEvents(List<Event> events, @Nullable String advertisingId)
+            throws ButtonNetworkException {
+
+        try {
+            JSONArray eventStream = new JSONArray();
+            for (int i = 0; i < events.size(); i++) {
+                JSONObject eventJson = events.get(i).toJson();
+                eventStream.put(i, eventJson);
+            }
+
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("ifa", advertisingId);
+            requestBody.put("events", eventStream);
+
+            ApiRequest apiRequest = new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
+                    "/v1/app/events")
+                    .setBody(requestBody)
+                    .build();
+            connectionManager.executeRequest(apiRequest);
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating request body", e);
+            throw new ButtonNetworkException(e);
+        }
+
+        return null;
+    }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
@@ -41,7 +41,8 @@ interface ButtonInternal {
     @Nullable
     String getApplicationId(ButtonRepository buttonRepository);
 
-    void trackIncomingIntent(ButtonRepository buttonRepository, Intent intent);
+    void trackIncomingIntent(ButtonRepository buttonRepository, DeviceManager deviceManager,
+            Features features, Intent intent);
 
     void trackOrder(ButtonRepository buttonRepository, DeviceManager manager,
             @NonNull Order order, @Nullable UserActivityListener listener);

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -72,7 +72,8 @@ public final class ButtonMerchant {
      * @param intent An intent that has entered your app from a third party source.
      */
     public static void trackIncomingIntent(@NonNull Context context, @NonNull Intent intent) {
-        buttonInternal.trackIncomingIntent(getButtonRepository(context), intent);
+        buttonInternal.trackIncomingIntent(getButtonRepository(context), getDeviceManager(context),
+                features(), intent);
     }
 
     /**

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepository.java
@@ -56,5 +56,7 @@ interface ButtonRepository {
     void updateCheckDeferredDeepLink(boolean checkedDeferredDeepLink);
 
     void postOrder(Order order, DeviceManager deviceManager, Features features,
-                Task.Listener listener);
+            Task.Listener listener);
+
+    void reportEvent(DeviceManager deviceManager, Features features, Event event);
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -27,9 +27,11 @@ package com.usebutton.merchant;
 
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.usebutton.merchant.module.Features;
 
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -37,6 +39,8 @@ import java.util.concurrent.ExecutorService;
  */
 
 final class ButtonRepositoryImpl implements ButtonRepository {
+
+    private static final String TAG = ButtonRepository.class.getSimpleName();
 
     private final ButtonApi buttonApi;
     private final PersistenceManager persistenceManager;
@@ -125,5 +129,22 @@ final class ButtonRepositoryImpl implements ButtonRepository {
         executorService.submit(
                 new PostOrderTask(listener, buttonApi, order, getApplicationId(),
                         getSourceToken(), deviceManager, features, new ThreadManager()));
+    }
+
+    @Override
+    public void reportEvent(DeviceManager deviceManager, Features features, final Event event) {
+        EventReportingTask task = new EventReportingTask(buttonApi, deviceManager, features,
+                Collections.singletonList(event), new Task.Listener<Void>() {
+            @Override
+            public void onTaskComplete(@Nullable Void object) {
+                // ignored
+            }
+
+            @Override
+            public void onTaskError(Throwable throwable) {
+                Log.e(TAG, String.format("Error reporting event [%s]", event.getName()), throwable);
+            }
+        });
+        executorService.submit(task);
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/Event.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/Event.java
@@ -1,0 +1,116 @@
+/*
+ * Event.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Internal class used to encapsulate event data.
+ */
+class Event {
+
+    private static final String TAG = Event.class.getSimpleName();
+
+    /**
+     * Supported event names.
+     */
+    enum Name {
+        DEEPLINK_OPENED("btn:deeplink-opened");
+
+        private final String eventName;
+
+        Name(String eventName) {
+            this.eventName = eventName;
+        }
+
+        @Override
+        public String toString() {
+            return eventName;
+        }
+    }
+
+    /**
+     * Supported event properties
+     */
+    enum Property {
+        URL("url");
+
+        private final String propertyName;
+
+        Property(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        @Override
+        public String toString() {
+            return propertyName;
+        }
+    }
+
+    private final Name name;
+    @Nullable
+    private final String sourceToken;
+    private final JSONObject eventBody;
+
+    Event(Name name, @Nullable String sourceToken) {
+        this.name = name;
+        this.sourceToken = sourceToken;
+        this.eventBody = new JSONObject();
+    }
+
+    void addProperty(Property key, @Nullable String value) {
+        try {
+            eventBody.put(key.propertyName, value);
+        } catch (JSONException e) {
+            Log.e(TAG, String.format("Error adding property [%s] to event [%s]", key, name), e);
+        }
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    @Nullable
+    public String getSourceToken() {
+        return sourceToken;
+    }
+
+    public JSONObject getEventBody() {
+        return eventBody;
+    }
+
+    JSONObject toJson() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("name", name.eventName);
+        json.put("promotion_source_token", sourceToken);
+        json.put("value", eventBody);
+        return json;
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -88,10 +88,16 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         Intent intent = mock(Intent.class);
         Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
         when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
         when(uri.getQueryParameter("btn_ref")).thenReturn("valid_source_token");
 
-        buttonInternal.trackIncomingIntent(buttonRepository, intent);
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
+
         verify(buttonRepository).setSourceToken("valid_source_token");
     }
 
@@ -101,9 +107,46 @@ public class ButtonInternalImplTest {
         Intent intent = mock(Intent.class);
         when(intent.getData()).thenReturn(null);
 
-        buttonInternal.trackIncomingIntent(buttonRepository, intent);
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken(anyString());
+    }
+
+    @Test
+    public void trackIncomingIntent_withValidIntentData_shouldReportDeeplinkOpenEvent() {
+        ButtonRepository buttonRepository = mock(ButtonRepository.class);
+        Intent intent = mock(Intent.class);
+        Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
+        when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
+        when(uri.getQueryParameter("btn_ref")).thenReturn("valid_source_token");
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
+
+        verify(buttonRepository).reportEvent(any(DeviceManager.class), any(Features.class),
+                eventCaptor.capture());
+        Event event = eventCaptor.getValue();
+
+        assertEquals(Event.Name.DEEPLINK_OPENED, event.getName());
+    }
+
+    @Test
+    public void trackIncomingIntent_withNullIntentData_shouldNotReportDeeplinkOpenEvent() {
+        ButtonRepository buttonRepository = mock(ButtonRepository.class);
+        Intent intent = mock(Intent.class);
+        when(intent.getData()).thenReturn(null);
+
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
+
+        verify(buttonRepository, never()).reportEvent(any(DeviceManager.class),
+                any(Features.class), any(Event.class));
     }
 
     @Test
@@ -199,14 +242,19 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         Intent intent = mock(Intent.class);
         Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
         when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
         when(uri.getQueryParameter("btn_ref")).thenReturn(validToken);
 
         // Add Listener
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, intent);
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
 
         verify(buttonRepository).setSourceToken(validToken);
         verify(listener).onAttributionTokenChanged(validToken);
@@ -217,14 +265,19 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         Intent intent = mock(Intent.class);
         Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
         when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
         when(uri.getQueryParameter("btn_ref")).thenReturn(null);
 
         // Add Listener
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, intent);
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken(null);
         verify(listener, never()).onAttributionTokenChanged(null);
@@ -235,14 +288,19 @@ public class ButtonInternalImplTest {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         Intent intent = mock(Intent.class);
         Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
         when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
         when(uri.getQueryParameter("btn_ref")).thenReturn("");
 
         // Add Listener
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, intent);
+        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
+                mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken("");
         verify(listener, never()).onAttributionTokenChanged("");
@@ -431,13 +489,48 @@ public class ButtonInternalImplTest {
     }
 
     @Test
+    public void handlePostInstallIntent_previouslySetTokenFromDirectDeeplink_shouldNotPersistTokenNorProvideDeferredDeeplink() {
+        ButtonRepository buttonRepository = mock(ButtonRepository.class);
+        PostInstallIntentListener postInstallIntentListener = mock(PostInstallIntentListener.class);
+        DeviceManager deviceManager = mock(DeviceManager.class);
+        Features features = mock(Features.class);
+        Intent intent = mock(Intent.class);
+        Uri link = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
+        when(link.buildUpon()).thenReturn(builder);
+        when(link.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(link);
+        when(link.getQueryParameter("btn_ref")).thenReturn("valid_token");
+        when(intent.getData()).thenReturn(link);
+        when(buttonRepository.getApplicationId()).thenReturn("valid_application_id");
+        ArgumentCaptor<GetPendingLinkTask.Listener<PostInstallLink>> listenerArgumentCaptor =
+                ArgumentCaptor.forClass(GetPendingLinkTask.Listener.class);
+        PostInstallLink.Attribution attribution =
+                new PostInstallLink.Attribution("valid_source_token", "SMS");
+        PostInstallLink postInstallLink =
+                new PostInstallLink(true, "ddl-6faffd3451edefd3", "uber://asdfasfasf",
+                        attribution);
+
+        buttonInternal.trackIncomingIntent(buttonRepository, deviceManager, features, intent);
+        buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager,
+                features, "com.usebutton.merchant", postInstallIntentListener);
+
+        verify(buttonRepository).getPendingLink(eq(deviceManager), eq(features),
+                listenerArgumentCaptor.capture());
+        listenerArgumentCaptor.getValue().onTaskComplete(postInstallLink);
+
+        verify(postInstallIntentListener).onResult((Intent) isNull(), (Throwable) isNull());
+        verify(buttonRepository, never()).setSourceToken("valid_source_token");
+    }
+
+    @Test
     public void reportOrder_nullApplicationId_verifyException() {
         ButtonRepository buttonRepository = mock(ButtonRepository.class);
         when(buttonRepository.getApplicationId()).thenReturn(null);
         OrderListener orderListener = mock(OrderListener.class);
 
         buttonInternal.reportOrder(buttonRepository, mock(DeviceManager.class),
-               mock(Features.class), mock(Order.class), orderListener);
+                mock(Features.class), mock(Order.class), orderListener);
 
         verify(orderListener).onResult(any(ApplicationIdNotFoundException.class));
     }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -89,7 +89,8 @@ public class ButtonMerchantTest {
     @Test
     public void trackIncomingIntent_verifyButtonInternal() {
         ButtonMerchant.trackIncomingIntent(context, mock(Intent.class));
-        verify(buttonInternal).trackIncomingIntent(any(ButtonRepository.class), any(Intent.class));
+        verify(buttonInternal).trackIncomingIntent(any(ButtonRepository.class),
+                any(DeviceManager.class), any(Features.class), any(Intent.class));
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
@@ -137,4 +137,12 @@ public class ButtonRepositoryImplTest {
 
         verify(executorService).submit(any(PostOrderTask.class));
     }
+
+    @Test
+    public void reportEvent_executeTask() {
+        buttonRepository.reportEvent(mock(DeviceManager.class), mock(Features.class),
+                mock(Event.class));
+
+        verify(executorService).submit(any(EventReportingTask.class));
+    }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/EventReportingTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/EventReportingTaskTest.java
@@ -1,0 +1,91 @@
+/*
+ * EventReportingTaskTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import com.usebutton.merchant.module.Features;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventReportingTaskTest {
+
+    @Mock private ButtonApi buttonApi;
+    @Mock private DeviceManager deviceManager;
+    @Mock private Features features;
+    @Mock private Task.Listener listener;
+
+    private List<Event> events;
+
+    private EventReportingTask task;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        events = new ArrayList<>();
+        task = new EventReportingTask(buttonApi, deviceManager, features, events, listener);
+    }
+
+    @Test
+    public void execute_includesIfa_hasAdvertisingId_verifyApiCall() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(true);
+        String advertisingId = "valid_advertising_id";
+        when(deviceManager.getAdvertisingId()).thenReturn(advertisingId);
+
+        task.execute();
+
+        verify(buttonApi).postEvents(events, advertisingId);
+    }
+
+    @Test
+    public void execute_includesIfa_nullAdvertisingId_verifyNullAdvertisingId() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(true);
+        when(deviceManager.getAdvertisingId()).thenReturn(null);
+
+        task.execute();
+
+        verify(buttonApi).postEvents(eq(events), (String) isNull());
+    }
+
+    @Test
+    public void execute_doesNotIncludesIfa_verifyNullAdvertisingId() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(false);
+        when(deviceManager.getAdvertisingId()).thenReturn("");
+
+        task.execute();
+
+        verify(buttonApi).postEvents(eq(events), (String) isNull());
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/EventTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/EventTest.java
@@ -1,0 +1,64 @@
+/*
+ * EventTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EventTest {
+
+    @Test
+    public void constructor_shouldConstructEmptyEvent() {
+        Event event = new Event(Event.Name.DEEPLINK_OPENED, "valid_token");
+
+        assertEquals(Event.Name.DEEPLINK_OPENED, event.getName());
+        assertEquals("valid_token", event.getSourceToken());
+        assertEquals((new JSONObject()).toString(), event.getEventBody().toString());
+    }
+
+    @Test
+    public void addProperty_shouldAddEventProperty() throws Exception {
+        Event event = new Event(Event.Name.DEEPLINK_OPENED, "valid_token");
+        event.addProperty(Event.Property.URL, "valid_url");
+
+        assertEquals("valid_url", event.getEventBody().getString(Event.Property.URL.toString()));
+    }
+
+    @Test
+    public void toJson_shouldConvertEventToJsonObject() throws Exception {
+        Event event = new Event(Event.Name.DEEPLINK_OPENED, "valid_token");
+        event.addProperty(Event.Property.URL, "valid_url");
+
+        JSONObject eventJson = event.toJson();
+
+        assertEquals(Event.Name.DEEPLINK_OPENED.toString(), eventJson.getString("name"));
+        assertEquals("valid_token", eventJson.getString("promotion_source_token"));
+        assertTrue(eventJson.has("value"));
+    }
+}

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -15,6 +15,7 @@ import com.usebutton.merchant.ButtonMerchant
 import com.usebutton.merchant.Order
 import java.util.Collections
 import java.util.Date
+import java.util.Locale
 import java.util.Random
 import java.util.UUID
 
@@ -143,7 +144,9 @@ class KotlinActivity : AppCompatActivity() {
 
     companion object {
         private const val TAG = "KotlinActivity"
-        private const val TEST_URL = "https://sample-merchant.usebutton.com/?btn_ref=srctok-test"
+        private var TEST_URL = String.format(Locale.getDefault(),
+                "https://example.com/p/123?btn_ref=srctok-abc%d&from_landing=true&from_tracking=false&btn_blargh=blergh&other_param=some_val",
+                Random().nextInt(100000))
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -49,6 +49,7 @@ import com.usebutton.merchant.UserActivityListener;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -180,9 +181,11 @@ public class MainActivity extends AppCompatActivity {
             public void onClick(View v) {
 
                 Intent intent = new Intent();
-                intent.setData(
-                        Uri.parse("https://sample-merchant.usebutton.com/?btn_ref=srctok-test"
-                                + new Random().nextInt(100000)));
+                String url = String.format(Locale.getDefault(),
+                        "https://example.com/p/123?btn_ref=srctok-abc%d&from_landing=true&"
+                                + "from_tracking=false&btn_blargh=blergh&other_param=some_val",
+                        new Random().nextInt(100000));
+                intent.setData(Uri.parse(url));
                 ButtonMerchant.trackIncomingIntent(v.getContext(), intent);
             }
         });


### PR DESCRIPTION
### Goals :soccer:
This PR sets up the foundation to report client-side events to the Button server. 

### Implementation :construction:
The first reportable event is `btn:deeplink-opened` which will be reported whenever a **direct** deeplink is received. Additionally, I've added a check to ensure that if we've already received a direct deeplink then the result of the deferred deeplink is ignored.

