### PR TITLE
Allow broken events requests to be made

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
@@ -41,6 +41,9 @@ interface ButtonApi {
     void setApplicationId(String applicationId);
 
     @Nullable
+    String getApplicationId();
+
+    @Nullable
     @WorkerThread
     PostInstallLink getPendingLink(String applicationId, @Nullable String advertisingId,
             Map<String, String> signalsMap)

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -68,6 +68,12 @@ final class ButtonApiImpl implements ButtonApi {
     }
 
     @Nullable
+    @Override
+    public String getApplicationId() {
+        return connectionManager.getApplicationId();
+    }
+
+    @Nullable
     @WorkerThread
     @Override
     public PostInstallLink getPendingLink(String applicationId, @Nullable String advertisingId,

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Pattern;
 
 /**
  * ButtonInternalImpl class should implement everything needed for {@link ButtonMerchant}
@@ -72,19 +71,16 @@ final class ButtonInternalImpl implements ButtonInternal {
      */
     private final AtomicBoolean hasReceivedDirectDeeplink = new AtomicBoolean();
 
-    private static final Pattern APP_ID_PATTERN = Pattern.compile("^app-[0-9a-zA-Z]+$");
-
     ButtonInternalImpl(Executor executor) {
         this.attributionTokenListeners = new ArrayList<>();
         this.executor = executor;
     }
 
     public void configure(ButtonRepository buttonRepository, String applicationId) {
-        if (!APP_ID_PATTERN.matcher(applicationId).matches()) {
+        if (!ButtonUtil.isApplicationIdValid(applicationId)) {
             Log.e(TAG, "Application ID [" + applicationId + "] is not valid. "
                     + "You can find your Application ID in the dashboard by logging in at"
                     + " https://app.usebutton.com/");
-            return;
         }
 
         buttonRepository.setApplicationId(applicationId);

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -51,7 +51,7 @@ public final class ButtonMerchant {
     static ButtonInternal buttonInternal = new ButtonInternalImpl(executor);
 
     private static ExecutorService executorService = Executors.newSingleThreadExecutor();
-    private static final String BASE_URL = "https://mobileapi.usebutton.com";
+    static final String BASE_URL = "https://mobileapi.usebutton.com";
     static final String FMT_BASE_URL_APP_ID = "https://%s.mobileapi.usebutton.com";
 
     /**

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -48,9 +48,8 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     private final PersistenceManager persistenceManager;
     private final ExecutorService executorService;
 
-    private String applicationId;
-
     private static ButtonRepository buttonRepository;
+    private boolean isConfigured;
     private List<Task<?>> pendingTasks = new CopyOnWriteArrayList<>();
 
     static ButtonRepository getInstance(ButtonApi buttonApi, PersistenceManager persistenceManager,
@@ -73,7 +72,7 @@ final class ButtonRepositoryImpl implements ButtonRepository {
 
     @Override
     public void setApplicationId(String applicationId) {
-        this.applicationId = applicationId;
+        isConfigured = true;
         buttonApi.setApplicationId(applicationId);
 
         for (Task<?> task : pendingTasks) {
@@ -85,7 +84,7 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     @Nullable
     @Override
     public String getApplicationId() {
-        return applicationId;
+        return buttonApi.getApplicationId();
     }
 
     @Override
@@ -157,7 +156,7 @@ final class ButtonRepositoryImpl implements ButtonRepository {
      * @param task the task to submit
      */
     private void invokeIfConfigured(Task<?> task) {
-        if (getApplicationId() != null) {
+        if (isConfigured) {
             executorService.submit(task);
         } else {
             Log.d(TAG, "Application ID unavailable! Queueing Task.");

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
@@ -61,9 +61,10 @@ final class ButtonUtil {
 
     private static final Pattern EMAIL_REGEX_PATTERN = Pattern.compile(EMAIL_REGEX);
 
+    private static final Pattern APP_ID_PATTERN = Pattern.compile("^app-[0-9a-zA-Z]+$");
+
     /**
      * @param date date to be formatted
-     *
      * @return date formatted in ISO_8601 format
      */
     public static String formatDate(Date date) {
@@ -90,6 +91,10 @@ final class ButtonUtil {
 
     public static boolean isValidEmail(String email) {
         return EMAIL_REGEX_PATTERN.matcher(email).matches();
+    }
+
+    public static boolean isApplicationIdValid(@Nullable String applicationId) {
+        return applicationId != null && APP_ID_PATTERN.matcher(applicationId).matches();
     }
 
     private static String encodeHex(byte[] digest) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManager.java
@@ -25,6 +25,8 @@
 
 package com.usebutton.merchant;
 
+import android.support.annotation.Nullable;
+
 import com.usebutton.merchant.exception.ButtonNetworkException;
 
 /**
@@ -33,6 +35,9 @@ import com.usebutton.merchant.exception.ButtonNetworkException;
 interface ConnectionManager {
 
     void setApplicationId(String applicationId);
+
+    @Nullable
+    String getApplicationId();
 
     NetworkResponse executeRequest(ApiRequest request) throws ButtonNetworkException;
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ConnectionManagerImpl.java
@@ -90,10 +90,21 @@ final class ConnectionManagerImpl implements ConnectionManager {
 
     @Override
     public void setApplicationId(String applicationId) {
-        this.applicationId = applicationId;
+        // Only cache the application ID if it is valid
+        // However, we would still let the network requests proceed instead of failing silently
+        // on the client-side.
+        if (ButtonUtil.isApplicationIdValid(applicationId)) {
+            this.applicationId = applicationId;
 
-        // Update the endpoint to the App ID flavor
-        baseUrl = String.format(ButtonMerchant.FMT_BASE_URL_APP_ID, applicationId);
+            // Update the endpoint to the App ID flavor
+            baseUrl = String.format(ButtonMerchant.FMT_BASE_URL_APP_ID, applicationId);
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getApplicationId() {
+        return applicationId;
     }
 
     @Override

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -50,7 +50,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ButtonInternalImplTest {
@@ -71,15 +70,6 @@ public class ButtonInternalImplTest {
         buttonInternal.configure(buttonRepository, "app-abcdef1234567890");
 
         verify(buttonRepository).setApplicationId("app-abcdef1234567890");
-    }
-
-    @Test
-    public void configure_invalidAppId_shouldNotConfigure() {
-        ButtonRepository buttonRepository = mock(ButtonRepository.class);
-
-        buttonInternal.configure(buttonRepository, "invalid_application_id");
-
-        verifyZeroInteractions(buttonRepository);
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonRepositoryImplTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ButtonRepositoryImplTest {
@@ -63,16 +62,9 @@ public class ButtonRepositoryImplTest {
     }
 
     @Test
-    public void setApplicationId_cacheInMemory() {
-        buttonRepository.setApplicationId("valid_application_id");
-        assertEquals("valid_application_id", buttonRepository.getApplicationId());
-        verifyZeroInteractions(persistenceManager);
-    }
-
-    @Test
     public void setApplicationId_provideToButtonApi() {
-        buttonRepository.setApplicationId("valid_application_id");
-        verify(buttonApi).setApplicationId("valid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
+        verify(buttonApi).setApplicationId("invalid_application_id");
     }
 
     @Test
@@ -84,7 +76,7 @@ public class ButtonRepositoryImplTest {
         buttonRepository.reportEvent(mock(DeviceManager.class), mock(Features.class),
                 mock(Event.class));
 
-        buttonRepository.setApplicationId("valid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
 
         verify(executorService, times(3)).submit(any(EventReportingTask.class));
     }
@@ -98,19 +90,13 @@ public class ButtonRepositoryImplTest {
         buttonRepository.reportEvent(mock(DeviceManager.class), mock(Features.class),
                 mock(Event.class));
 
-        buttonRepository.setApplicationId("valid_application_id");
-        buttonRepository.setApplicationId("valid_application_id");
-        buttonRepository.setApplicationId("valid_application_id");
-        buttonRepository.setApplicationId("valid_application_id");
-        buttonRepository.setApplicationId("valid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
 
         verify(executorService, times(3)).submit(any(EventReportingTask.class));
-    }
-
-    @Test
-    public void getApplicationId_returnValidAppId() {
-        buttonRepository.setApplicationId("valid_application_id");
-        assertEquals("valid_application_id", buttonRepository.getApplicationId());
     }
 
     @Test
@@ -166,7 +152,7 @@ public class ButtonRepositoryImplTest {
 
     @Test
     public void reportEvent_configured_executeTask() {
-        buttonRepository.setApplicationId("valid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
         buttonRepository.reportEvent(mock(DeviceManager.class), mock(Features.class),
                 mock(Event.class));
 
@@ -179,7 +165,7 @@ public class ButtonRepositoryImplTest {
                 mock(Event.class));
 
         verify(executorService, never()).submit(any(EventReportingTask.class));
-        buttonRepository.setApplicationId("valid_application_id");
+        buttonRepository.setApplicationId("invalid_application_id");
 
         verify(executorService).submit(any(EventReportingTask.class));
     }


### PR DESCRIPTION
### Goals :soccer:
To be notified of a faulty integration if a Brand accidentally configures the Merchant Library with an invalid Application ID

### Implementation :construction:
The `ConnectionManager` now holds the application ID (still in memory). If it is invalid, it won't cache the ID nor will it update the API endpoint. However, it will let the API requests go thru (to the default API endpoint).

This only affects deeplink event requests. Others will continue to be blocked at the callsite, as before.
