### PR TITLE
Add user activity reporting

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ActivityReportingTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ActivityReportingTask.java
@@ -41,22 +41,24 @@ public class ActivityReportingTask extends Task<Void> {
     private final Features features;
     private final String activityName;
     private final List<ButtonProductCompatible> products;
+    private final String sourceToken;
 
     public ActivityReportingTask(ButtonApi buttonApi, DeviceManager deviceManager,
             Features features, String activityName, List<ButtonProductCompatible> products,
-            @Nullable Listener<Void> listener) {
+            @Nullable String sourceToken, @Nullable Listener<Void> listener) {
         super(listener);
         this.buttonApi = buttonApi;
         this.deviceManager = deviceManager;
         this.features = features;
         this.activityName = activityName;
         this.products = products;
+        this.sourceToken = sourceToken;
     }
 
     @Nullable
     @Override
     Void execute() throws Exception {
         String advertisingId = features.getIncludesIfa() ? deviceManager.getAdvertisingId() : null;
-        return buttonApi.postActivity(activityName, products, advertisingId);
+        return buttonApi.postActivity(activityName, products, sourceToken, advertisingId);
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ActivityReportingTask.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ActivityReportingTask.java
@@ -1,7 +1,7 @@
 /*
- * ButtonRepository.java
+ * ActivityReportingTask.java
  *
- * Copyright (c) 2018 Button, Inc. (https://usebutton.com)
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,33 +32,31 @@ import com.usebutton.merchant.module.Features;
 import java.util.List;
 
 /**
- * Internal data layer interface.
+ * Asynchronous task used to report user activity to Button.
  */
-interface ButtonRepository {
+public class ActivityReportingTask extends Task<Void> {
 
-    void setApplicationId(String applicationId);
+    private final ButtonApi buttonApi;
+    private final DeviceManager deviceManager;
+    private final Features features;
+    private final String activityName;
+    private final List<ButtonProductCompatible> products;
+
+    public ActivityReportingTask(ButtonApi buttonApi, DeviceManager deviceManager,
+            Features features, String activityName, List<ButtonProductCompatible> products,
+            @Nullable Listener<Void> listener) {
+        super(listener);
+        this.buttonApi = buttonApi;
+        this.deviceManager = deviceManager;
+        this.features = features;
+        this.activityName = activityName;
+        this.products = products;
+    }
 
     @Nullable
-    String getApplicationId();
-
-    void setSourceToken(String sourceToken);
-
-    @Nullable
-    String getSourceToken();
-
-    void clear();
-
-    void getPendingLink(DeviceManager deviceManager, Features features,
-            Task.Listener<PostInstallLink> listener);
-
-    boolean checkedDeferredDeepLink();
-
-    void updateCheckDeferredDeepLink(boolean checkedDeferredDeepLink);
-
-    void postOrder(Order order, DeviceManager deviceManager, Features features,
-            Task.Listener listener);
-
-    void trackActivity(String eventName, List<ButtonProductCompatible> products);
-
-    void reportEvent(DeviceManager deviceManager, Features features, Event event);
+    @Override
+    Void execute() throws Exception {
+        String advertisingId = features.getIncludesIfa() ? deviceManager.getAdvertisingId() : null;
+        return buttonApi.postActivity(activityName, products, advertisingId);
+    }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
@@ -57,7 +57,8 @@ interface ButtonApi {
     @Nullable
     @WorkerThread
     Void postActivity(String activityName, List<ButtonProductCompatible> products,
-            @Nullable String advertisingId) throws ButtonNetworkException;
+            @Nullable String sourceToken, @Nullable String advertisingId)
+            throws ButtonNetworkException;
 
     @Nullable
     @WorkerThread

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApi.java
@@ -56,6 +56,11 @@ interface ButtonApi {
 
     @Nullable
     @WorkerThread
+    Void postActivity(String activityName, List<ButtonProductCompatible> products,
+            @Nullable String advertisingId) throws ButtonNetworkException;
+
+    @Nullable
+    @WorkerThread
     Void postEvents(List<Event> events, @Nullable String advertisingId)
             throws ButtonNetworkException;
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -204,6 +204,68 @@ final class ButtonApiImpl implements ButtonApi {
 
     @Nullable
     @Override
+    public Void postActivity(String activityName, List<ButtonProductCompatible> products,
+            @Nullable String advertisingId) throws ButtonNetworkException {
+
+        try {
+            JSONArray productsArray = new JSONArray();
+            for (int i = 0; i < products.size(); i++) {
+                ButtonProductCompatible product = products.get(i);
+                List<String> categories = product.getCategories();
+                Map<String, String> attributes = product.getAttributes();
+                JSONObject productJson = new JSONObject();
+
+                // Convert categories list to JSON array
+                JSONArray categoriesJson = new JSONArray();
+                if (categories != null) {
+                    for (int j = 0; j < categories.size(); j++) {
+                        categoriesJson.put(j, categories.get(j));
+                    }
+                    productJson.put("categories", categoriesJson);
+                }
+
+                // Convert custom attributes map to JSON object
+                JSONObject attributesJson = new JSONObject();
+                if (attributes != null) {
+                    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                        attributesJson.putOpt(entry.getKey(), entry.getValue());
+                    }
+                    productJson.put("attributes", attributesJson);
+                }
+
+                // Put product data into a JSON object
+                productJson.put("id", product.getId());
+                productJson.put("upc", product.getUpc());
+                productJson.put("name", product.getName());
+                productJson.put("currency", product.getCurrency());
+                productJson.put("value", product.getValue());
+                productJson.put("quantity", product.getQuantity());
+                productJson.put("url", product.getUrl());
+
+                // Add to JSON array of products
+                productsArray.put(i, productJson);
+            }
+
+            JSONObject requestBody = new JSONObject();
+            requestBody.put("ifa", advertisingId);
+            requestBody.put("name", activityName);
+            requestBody.put("products", productsArray);
+
+            ApiRequest apiRequest = new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
+                    "/v1/app/activity")
+                    .setBody(requestBody)
+                    .build();
+            connectionManager.executeRequest(apiRequest);
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating request body", e);
+            throw new ButtonNetworkException(e);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
     public Void postEvents(List<Event> events, @Nullable String advertisingId)
             throws ButtonNetworkException {
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -209,49 +209,57 @@ final class ButtonApiImpl implements ButtonApi {
             throws ButtonNetworkException {
 
         try {
-            JSONArray productsArray = new JSONArray();
-            for (int i = 0; i < products.size(); i++) {
-                ButtonProductCompatible product = products.get(i);
-                List<String> categories = product.getCategories();
-                Map<String, String> attributes = product.getAttributes();
-                JSONObject productJson = new JSONObject();
-
-                // Convert categories list to JSON array
-                JSONArray categoriesJson = new JSONArray();
-                if (categories != null) {
-                    for (int j = 0; j < categories.size(); j++) {
-                        categoriesJson.put(j, categories.get(j));
-                    }
-                    productJson.put("categories", categoriesJson);
-                }
-
-                // Convert custom attributes map to JSON object
-                JSONObject attributesJson = new JSONObject();
-                if (attributes != null) {
-                    for (Map.Entry<String, String> entry : attributes.entrySet()) {
-                        attributesJson.putOpt(entry.getKey(), entry.getValue());
-                    }
-                    productJson.put("attributes", attributesJson);
-                }
-
-                // Put product data into a JSON object
-                productJson.put("id", product.getId());
-                productJson.put("upc", product.getUpc());
-                productJson.put("name", product.getName());
-                productJson.put("currency", product.getCurrency());
-                productJson.put("value", product.getValue());
-                productJson.put("quantity", product.getQuantity());
-                productJson.put("url", product.getUrl());
-
-                // Add to JSON array of products
-                productsArray.put(i, productJson);
-            }
-
             JSONObject requestBody = new JSONObject();
+            JSONObject activityBody = new JSONObject();
             requestBody.put("ifa", advertisingId);
             requestBody.put("btn_ref", sourceToken);
-            requestBody.put("name", activityName);
-            requestBody.put("products", productsArray);
+            activityBody.put("name", activityName);
+
+            if (!products.isEmpty()) {
+                JSONArray productsArray = new JSONArray();
+                for (int i = 0; i < products.size(); i++) {
+                    ButtonProductCompatible product = products.get(i);
+                    List<String> categories = product.getCategories();
+                    Map<String, String> attributes = product.getAttributes();
+                    JSONObject productJson = new JSONObject();
+
+                    // Convert categories list to JSON array
+                    JSONArray categoriesJson = new JSONArray();
+                    if (categories != null) {
+                        for (int j = 0; j < categories.size(); j++) {
+                            categoriesJson.put(j, categories.get(j));
+                        }
+                        productJson.put("categories", categoriesJson);
+                    }
+
+                    // Convert custom attributes map to JSON object
+                    JSONObject attributesJson = new JSONObject();
+                    if (attributes != null) {
+                        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                            attributesJson.putOpt(entry.getKey(), entry.getValue());
+                        }
+                        productJson.put("attributes", attributesJson);
+                    }
+
+                    // Put product data into a JSON object
+                    productJson.put("id", product.getId());
+                    productJson.put("upc", product.getUpc());
+                    productJson.put("name", product.getName());
+                    productJson.put("currency", product.getCurrency());
+                    productJson.put("value", product.getValue());
+                    productJson.put("quantity", product.getQuantity());
+                    productJson.put("url", product.getUrl());
+
+                    // Add to JSON array of products
+                    productsArray.put(i, productJson);
+                }
+
+                // Append products only if available
+                activityBody.put("products", productsArray);
+            }
+
+            // Append activity data to request body
+            requestBody.put("activity_data", activityBody);
 
             ApiRequest apiRequest = new ApiRequest.Builder(ApiRequest.RequestMethod.POST,
                     "/v1/app/activity")

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -205,7 +205,8 @@ final class ButtonApiImpl implements ButtonApi {
     @Nullable
     @Override
     public Void postActivity(String activityName, List<ButtonProductCompatible> products,
-            @Nullable String advertisingId) throws ButtonNetworkException {
+            @Nullable String sourceToken, @Nullable String advertisingId)
+            throws ButtonNetworkException {
 
         try {
             JSONArray productsArray = new JSONArray();
@@ -248,6 +249,7 @@ final class ButtonApiImpl implements ButtonApi {
 
             JSONObject requestBody = new JSONObject();
             requestBody.put("ifa", advertisingId);
+            requestBody.put("btn_ref", sourceToken);
             requestBody.put("name", activityName);
             requestBody.put("products", productsArray);
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -50,6 +50,8 @@ public final class ButtonMerchant {
     private static Executor executor = new MainThreadExecutor();
     @VisibleForTesting
     static ButtonInternal buttonInternal = new ButtonInternalImpl(executor);
+    @VisibleForTesting
+    static ButtonUserActivity activity = ButtonUserActivityImpl.getInstance();
 
     private static ExecutorService executorService = Executors.newSingleThreadExecutor();
     static final String BASE_URL = "https://mobileapi.usebutton.com";
@@ -64,6 +66,7 @@ public final class ButtonMerchant {
      */
     public static void configure(@NonNull Context context, @NonNull String applicationId) {
         buttonInternal.configure(getButtonRepository(context), applicationId);
+        ((ButtonUserActivityImpl) activity()).flushQueue(getButtonRepository(context));
     }
 
     /**
@@ -203,7 +206,7 @@ button#report-orders-to-buttons-order-api">Reporting Orders to Button</a>
      * @return Button user activity API
      */
     public static ButtonUserActivity activity() {
-        return ButtonUserActivityImpl.getInstance();
+        return activity;
     }
 
     private static ButtonRepository getButtonRepository(Context context) {
@@ -217,7 +220,8 @@ button#report-orders-to-buttons-order-api">Reporting Orders to Button</a>
 
         ButtonApi buttonApi = ButtonApiImpl.getInstance(connectionManager);
 
-        return ButtonRepositoryImpl.getInstance(buttonApi, persistenceManager, executorService);
+        return ButtonRepositoryImpl.getInstance(buttonApi, deviceManager, features(),
+                persistenceManager, executorService);
     }
 
     private static DeviceManager getDeviceManager(Context context) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -31,6 +31,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
+import com.usebutton.merchant.module.ButtonUserActivity;
 import com.usebutton.merchant.module.Features;
 
 import java.util.concurrent.Executor;
@@ -194,6 +195,15 @@ button#report-orders-to-buttons-order-api">Reporting Orders to Button</a>
      */
     public static Features features() {
         return FeaturesImpl.getInstance();
+    }
+
+    /**
+     * An interface through which user activities can be reported.
+     *
+     * @return Button user activity API
+     */
+    public static ButtonUserActivity activity() {
+        return ButtonUserActivityImpl.getInstance();
     }
 
     private static ButtonRepository getButtonRepository(Context context) {

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonProduct.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonProduct.java
@@ -1,0 +1,137 @@
+/*
+ * ButtonProduct.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.support.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A concrete implementation of the {@link ButtonProductCompatible} interface.
+ */
+public class ButtonProduct implements ButtonProductCompatible {
+
+    @Nullable private String id;
+    @Nullable private String upc;
+    @Nullable private List<String> categories;
+    @Nullable private String name;
+    @Nullable private String currency;
+    @Nullable private Integer value;
+    @Nullable private Integer quantity;
+    @Nullable private String url;
+    @Nullable private Map<String, String> attributes;
+
+    @Override
+    @Nullable
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    @Nullable
+    public String getUpc() {
+        return upc;
+    }
+
+    @Override
+    @Nullable
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    @Override
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @Nullable
+    public String getCurrency() {
+        return currency;
+    }
+
+    @Override
+    @Nullable
+    public Integer getValue() {
+        return value;
+    }
+
+    @Override
+    @Nullable
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    @Override
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setId(@Nullable String id) {
+        this.id = id;
+    }
+
+    public void setUpc(@Nullable String upc) {
+        this.upc = upc;
+    }
+
+    public void setCategories(@Nullable List<String> categories) {
+        this.categories = categories;
+    }
+
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    public void setCurrency(@Nullable String currency) {
+        this.currency = currency;
+    }
+
+    public void setValue(@Nullable Integer value) {
+        this.value = value;
+    }
+
+    public void setQuantity(@Nullable Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public void setUrl(@Nullable String url) {
+        this.url = url;
+    }
+
+    public void setAttributes(@Nullable Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonProductCompatible.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonProductCompatible.java
@@ -1,0 +1,92 @@
+/*
+ * ButtonProductCompatible.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.support.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An interface that defines the product properties that may be provided when reporting user
+ * activity.
+ */
+public interface ButtonProductCompatible {
+
+    /**
+     * @return the product identifier
+     */
+    @Nullable
+    String getId();
+
+    /**
+     * @return the UPC (Universal Product Code) of the product
+     */
+    @Nullable
+    String getUpc();
+
+    /**
+     * @return a flat array of the names of the categories to which the product belongs
+     */
+    @Nullable
+    List<String> getCategories();
+
+    /**
+     * @return the name of the product
+     */
+    @Nullable
+    String getName();
+
+    /**
+     * @return the ISO-4217 currency code in which the product's value is reported
+     */
+    @Nullable
+    String getCurrency();
+
+    /**
+     * @return the value of the order. Includes any discounts, if applicable. Example: 1234 for $12.34
+     */
+    @Nullable
+    Integer getValue();
+
+    /**
+     * @return the quantity of the product
+     */
+    @Nullable
+    Integer getQuantity();
+
+    /**
+     * @return the URL of the product
+     */
+    @Nullable
+    String getUrl();
+
+    /**
+     * @return any additional attributes to be included with the product
+     */
+    @Nullable
+    Map<String, String> getAttributes();
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonProductCompatible.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonProductCompatible.java
@@ -67,7 +67,7 @@ public interface ButtonProductCompatible {
     String getCurrency();
 
     /**
-     * @return the value of the order. Includes any discounts, if applicable. Example: 1234 for $12.34
+     * @return the value of the order. Includes any discounts, if applicable. e.g: 1234 for $12.34
      */
     @Nullable
     Integer getValue();

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonRepositoryImpl.java
@@ -139,7 +139,7 @@ final class ButtonRepositoryImpl implements ButtonRepository {
     @Override
     public void trackActivity(final String eventName, List<ButtonProductCompatible> products) {
         ActivityReportingTask task = new ActivityReportingTask(buttonApi, deviceManager, features,
-                eventName, products, new Task.Listener<Void>() {
+                eventName, products, getSourceToken(), new Task.Listener<Void>() {
             @Override
             public void onTaskComplete(@Nullable Void object) {
                 // ignored

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
@@ -34,6 +34,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+/**
+ * Public API handler class for reporting user activity.
+ */
 class ButtonUserActivityImpl implements ButtonUserActivity {
 
     @VisibleForTesting static final String EVENT_PRODUCT_VIEWED = "product-viewed";
@@ -104,11 +107,14 @@ class ButtonUserActivityImpl implements ButtonUserActivity {
         queuedActivityEvents.clear();
     }
 
+    /**
+     * Internal class representing an activity event
+     */
     private static class Event {
         private final String name;
         private final List<ButtonProductCompatible> products;
 
-        public Event(String name, List<ButtonProductCompatible> products) {
+        Event(String name, List<ButtonProductCompatible> products) {
             this.name = name;
             this.products = products;
         }

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
@@ -1,0 +1,59 @@
+/*
+ * ButtonUserActivityImpl.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.support.annotation.Nullable;
+
+import com.usebutton.merchant.module.ButtonUserActivity;
+
+import java.util.List;
+
+class ButtonUserActivityImpl implements ButtonUserActivity {
+
+    private static ButtonUserActivity activity;
+
+    static ButtonUserActivity getInstance() {
+        if (activity == null) {
+            activity = new ButtonUserActivityImpl();
+        }
+        return activity;
+    }
+
+    @Override
+    public void productViewed(@Nullable ButtonProductCompatible product) {
+
+    }
+
+    @Override
+    public void productAddedToCart(@Nullable ButtonProductCompatible product) {
+
+    }
+
+    @Override
+    public void cartViewed(@Nullable List<ButtonProductCompatible> products) {
+
+    }
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUserActivityImpl.java
@@ -26,14 +26,27 @@
 package com.usebutton.merchant;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.usebutton.merchant.module.ButtonUserActivity;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 class ButtonUserActivityImpl implements ButtonUserActivity {
 
+    @VisibleForTesting static final String EVENT_PRODUCT_VIEWED = "product-viewed";
+    @VisibleForTesting static final String EVENT_ADD_TO_CART = "add-to-cart";
+    @VisibleForTesting static final String EVENT_CART_VIEWED = "cart-viewed";
+
     private static ButtonUserActivity activity;
+
+    @Nullable
+    private ButtonRepository buttonRepository;
+    // TODO: Move logic to ButtonRepository
+    @VisibleForTesting
+    List<Event> queuedActivityEvents = new CopyOnWriteArrayList<>();
 
     static ButtonUserActivity getInstance() {
         if (activity == null) {
@@ -44,16 +57,60 @@ class ButtonUserActivityImpl implements ButtonUserActivity {
 
     @Override
     public void productViewed(@Nullable ButtonProductCompatible product) {
+        Event event = new Event(
+                EVENT_PRODUCT_VIEWED,
+                product != null ? Collections.singletonList(product)
+                        : Collections.<ButtonProductCompatible>emptyList()
+        );
 
+        trackOrQueueEvent(event);
     }
 
     @Override
     public void productAddedToCart(@Nullable ButtonProductCompatible product) {
+        Event event = new Event(
+                EVENT_ADD_TO_CART,
+                product != null ? Collections.singletonList(product)
+                        : Collections.<ButtonProductCompatible>emptyList()
+        );
 
+        trackOrQueueEvent(event);
     }
 
     @Override
     public void cartViewed(@Nullable List<ButtonProductCompatible> products) {
+        Event event = new Event(
+                EVENT_CART_VIEWED,
+                products != null ? products : Collections.<ButtonProductCompatible>emptyList()
+        );
 
+        trackOrQueueEvent(event);
+    }
+
+    private void trackOrQueueEvent(Event event) {
+        if (buttonRepository != null) {
+            buttonRepository.trackActivity(event.name, event.products);
+        } else {
+            queuedActivityEvents.add(event);
+        }
+    }
+
+    void flushQueue(ButtonRepository buttonRepository) {
+        this.buttonRepository = buttonRepository;
+
+        for (Event event : queuedActivityEvents) {
+            buttonRepository.trackActivity(event.name, event.products);
+        }
+        queuedActivityEvents.clear();
+    }
+
+    private static class Event {
+        private final String name;
+        private final List<ButtonProductCompatible> products;
+
+        public Event(String name, List<ButtonProductCompatible> products) {
+            this.name = name;
+            this.products = products;
+        }
     }
 }

--- a/button-merchant/src/main/java/com/usebutton/merchant/module/ButtonUserActivity.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/module/ButtonUserActivity.java
@@ -1,0 +1,59 @@
+/*
+ * ButtonUserActivity.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant.module;
+
+import android.support.annotation.Nullable;
+
+import com.usebutton.merchant.ButtonProductCompatible;
+
+import java.util.List;
+
+/**
+ * An interface through which user activities can be reported.
+ */
+public interface ButtonUserActivity {
+
+    /**
+     * Report that the user has viewed a product.
+     *
+     * @param product the viewed product
+     */
+    void productViewed(@Nullable ButtonProductCompatible product);
+
+    /**
+     * Report that the user has added a product to their cart.
+     *
+     * @param product the added product
+     */
+    void productAddedToCart(@Nullable ButtonProductCompatible product);
+
+    /**
+     * Report that the user viewed their cart.
+     *
+     * @param products the products in the cart
+     */
+    void cartViewed(@Nullable List<ButtonProductCompatible> products);
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ActivityReportingTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ActivityReportingTaskTest.java
@@ -48,6 +48,7 @@ public class ActivityReportingTaskTest {
     @Mock private Task.Listener<Void> listener;
 
     private String activityName = "test-activity";
+    private String sourceToken = "test-token";
     private List<ButtonProductCompatible> products = new ArrayList<>();
 
     private ActivityReportingTask task;
@@ -56,7 +57,7 @@ public class ActivityReportingTaskTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         task = new ActivityReportingTask(buttonApi, deviceManager, features, activityName,
-                products, listener);
+                products, sourceToken, listener);
     }
 
     @Test
@@ -67,7 +68,7 @@ public class ActivityReportingTaskTest {
 
         task.execute();
 
-        verify(buttonApi).postActivity(activityName, products, "valid_advertising_id");
+        verify(buttonApi).postActivity(activityName, products, sourceToken, "valid_advertising_id");
     }
 
     @Test
@@ -77,7 +78,8 @@ public class ActivityReportingTaskTest {
 
         task.execute();
 
-        verify(buttonApi).postActivity(eq(activityName), eq(products), (String) isNull());
+        verify(buttonApi).postActivity(eq(activityName), eq(products), eq(sourceToken),
+                (String) isNull());
     }
 
     @Test
@@ -87,6 +89,7 @@ public class ActivityReportingTaskTest {
 
         task.execute();
 
-        verify(buttonApi).postActivity(eq(activityName), eq(products), (String) isNull());
+        verify(buttonApi).postActivity(eq(activityName), eq(products), eq(sourceToken),
+                (String) isNull());
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ActivityReportingTaskTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ActivityReportingTaskTest.java
@@ -1,0 +1,92 @@
+/*
+ * ActivityReportingTaskTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import com.usebutton.merchant.module.Features;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ActivityReportingTaskTest {
+
+    @Mock private ButtonApi buttonApi;
+    @Mock private DeviceManager deviceManager;
+    @Mock private Features features;
+    @Mock private Task.Listener<Void> listener;
+
+    private String activityName = "test-activity";
+    private List<ButtonProductCompatible> products = new ArrayList<>();
+
+    private ActivityReportingTask task;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        task = new ActivityReportingTask(buttonApi, deviceManager, features, activityName,
+                products, listener);
+    }
+
+    @Test
+    public void execute_includesIfa_hasAdvertisingId_verifyApiCall() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(true);
+        String advertisingId = "valid_advertising_id";
+        when(deviceManager.getAdvertisingId()).thenReturn(advertisingId);
+
+        task.execute();
+
+        verify(buttonApi).postActivity(activityName, products, "valid_advertising_id");
+    }
+
+    @Test
+    public void execute_includesIfa_nullAdvertisingId_verifyNullAdvertisingId() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(true);
+        when(deviceManager.getAdvertisingId()).thenReturn(null);
+
+        task.execute();
+
+        verify(buttonApi).postActivity(eq(activityName), eq(products), (String) isNull());
+    }
+
+    @Test
+    public void execute_doesNotIncludesIfa_verifyNullAdvertisingId() throws Exception {
+        when(features.getIncludesIfa()).thenReturn(false);
+        when(deviceManager.getAdvertisingId()).thenReturn("");
+
+        task.execute();
+
+        verify(buttonApi).postActivity(eq(activityName), eq(products), (String) isNull());
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -375,9 +375,10 @@ public class ButtonApiImplTest {
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
+        JSONObject activityBody = requestBody.getJSONObject("activity_data");
 
-        assertEquals("test-activity", requestBody.getString("name"));
-        assertEquals(0, requestBody.getJSONArray("products").length());
+        assertEquals("test-activity", activityBody.getString("name"));
+        assertFalse(activityBody.has("products"));
         assertEquals("test-token", requestBody.getString("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
@@ -399,11 +400,12 @@ public class ButtonApiImplTest {
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
+        JSONObject activityBody = requestBody.getJSONObject("activity_data");
 
-        assertEquals("test-activity", requestBody.getString("name"));
-        assertEquals(2, requestBody.getJSONArray("products").length());
-        assertEquals("one", requestBody.getJSONArray("products").getJSONObject(0).getString("id"));
-        assertEquals("two", requestBody.getJSONArray("products").getJSONObject(1).getString("id"));
+        assertEquals("test-activity", activityBody.getString("name"));
+        assertEquals(2, activityBody.getJSONArray("products").length());
+        assertEquals("one", activityBody.getJSONArray("products").getJSONObject(0).getString("id"));
+        assertEquals("two", activityBody.getJSONArray("products").getJSONObject(1).getString("id"));
         assertEquals("test-token", requestBody.getString("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
@@ -417,10 +419,11 @@ public class ButtonApiImplTest {
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
+        JSONObject activityBody = requestBody.getJSONObject("activity_data");
 
-        assertEquals("test-activity", requestBody.getString("name"));
-        assertEquals(1, requestBody.getJSONArray("products").length());
-        assertEquals(0, requestBody.getJSONArray("products").getJSONObject(0).length());
+        assertEquals("test-activity", activityBody.getString("name"));
+        assertEquals(1, activityBody.getJSONArray("products").length());
+        assertEquals(0, activityBody.getJSONArray("products").getJSONObject(0).length());
         assertFalse(requestBody.has("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
@@ -451,12 +454,13 @@ public class ButtonApiImplTest {
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
+        JSONObject activityBody = requestBody.getJSONObject("activity_data");
 
         assertEquals("test-ifa", requestBody.getString("ifa"));
         assertEquals("test-token", requestBody.getString("btn_ref"));
-        assertEquals("test-activity", requestBody.getString("name"));
-        assertEquals(1, requestBody.getJSONArray("products").length());
-        JSONObject productJson = requestBody.getJSONArray("products").getJSONObject(0);
+        assertEquals("test-activity", activityBody.getString("name"));
+        assertEquals(1, activityBody.getJSONArray("products").length());
+        JSONObject productJson = activityBody.getJSONArray("products").getJSONObject(0);
         assertEquals("test-id", productJson.getString("id"));
         assertEquals("test-upc", productJson.getString("upc"));
         assertEquals("test-name", productJson.getString("name"));

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -40,10 +40,12 @@ import org.mockito.MockitoAnnotations;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -349,6 +351,121 @@ public class ButtonApiImplTest {
         JSONObject requestBody = apiRequest.getBody();
         JSONObject customerJson = requestBody.getJSONObject("customer");
         assertEquals(customerEmail, customerJson.getString("email_sha256"));
+    }
+
+    @Test
+    public void postActivity_validateRequest() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+
+        buttonApi.postActivity("test-activity", Collections.<ButtonProductCompatible>emptyList(),
+                null);
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+
+        assertEquals("/v1/app/activity", apiRequest.getPath());
+        assertEquals(ApiRequest.RequestMethod.POST, apiRequest.getRequestMethod());
+    }
+
+    @Test
+    public void postActivity_noProducts_shouldPostActivity() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+
+        buttonApi.postActivity("test-activity", Collections.<ButtonProductCompatible>emptyList(),
+                null);
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+        JSONObject requestBody = apiRequest.getBody();
+
+        assertEquals("test-activity", requestBody.getString("name"));
+        assertEquals(0, requestBody.getJSONArray("products").length());
+        assertFalse(requestBody.has("ifa"));
+    }
+
+    @Test
+    public void postActivity_multipleProducts_shouldPostActivity() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+        final ButtonProductCompatible productOne = new ButtonProduct() {{
+            setId("one");
+        }};
+        final ButtonProductCompatible productTwo = new ButtonProduct() {{
+            setId("two");
+        }};
+
+        buttonApi.postActivity("test-activity", new ArrayList<ButtonProductCompatible>() {{
+            add(productOne);
+            add(productTwo);
+        }}, null);
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+        JSONObject requestBody = apiRequest.getBody();
+
+        assertEquals("test-activity", requestBody.getString("name"));
+        assertEquals(2, requestBody.getJSONArray("products").length());
+        assertEquals("one", requestBody.getJSONArray("products").getJSONObject(0).getString("id"));
+        assertEquals("two", requestBody.getJSONArray("products").getJSONObject(1).getString("id"));
+        assertFalse(requestBody.has("ifa"));
+    }
+
+    @Test
+    public void postActivity_withEmptyProductInfo_shouldPostActivity() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+        ButtonProductCompatible product = new ButtonProduct();
+
+        buttonApi.postActivity("test-activity", Collections.singletonList(product), null);
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+        JSONObject requestBody = apiRequest.getBody();
+
+        assertEquals("test-activity", requestBody.getString("name"));
+        assertEquals(1, requestBody.getJSONArray("products").length());
+        assertEquals(0, requestBody.getJSONArray("products").getJSONObject(0).length());
+        assertFalse(requestBody.has("ifa"));
+    }
+
+    @Test
+    public void postActivity_withCompleteProductInfo_shouldPostActivity() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+        List<String> categories = new ArrayList<>();
+        categories.add("cat-one");
+        categories.add("cat-two");
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attr-one", "1");
+        attributes.put("attr-two", "2");
+        final ButtonProduct product = new ButtonProduct();
+        product.setId("test-id");
+        product.setUpc("test-upc");
+        product.setCategories(categories);
+        product.setName("test-name");
+        product.setCurrency("test-curr");
+        product.setQuantity(2);
+        product.setValue(1234);
+        product.setUrl("test-url");
+        product.setAttributes(attributes);
+
+        buttonApi.postActivity("test-activity", new ArrayList<ButtonProductCompatible>() {{
+            add(product);
+        }}, "test-ifa");
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+        JSONObject requestBody = apiRequest.getBody();
+
+        assertEquals("test-ifa", requestBody.getString("ifa"));
+        assertEquals("test-activity", requestBody.getString("name"));
+        assertEquals(1, requestBody.getJSONArray("products").length());
+        JSONObject productJson = requestBody.getJSONArray("products").getJSONObject(0);
+        assertEquals("test-id", productJson.getString("id"));
+        assertEquals("test-upc", productJson.getString("upc"));
+        assertEquals("test-name", productJson.getString("name"));
+        assertEquals("test-curr", productJson.getString("currency"));
+        assertEquals("test-url", productJson.getString("url"));
+        assertEquals(2, productJson.getInt("quantity"));
+        assertEquals(1234, productJson.getInt("value"));
+        assertEquals(2, productJson.getJSONArray("categories").length());
+        assertEquals("cat-one", productJson.getJSONArray("categories").getString(0));
+        assertEquals("cat-two", productJson.getJSONArray("categories").getString(1));
+        assertEquals(2, productJson.getJSONObject("attributes").length());
+        assertEquals("1", productJson.getJSONObject("attributes").getString("attr-one"));
+        assertEquals("2", productJson.getJSONObject("attributes").getString("attr-two"));
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -358,7 +358,7 @@ public class ButtonApiImplTest {
         ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
 
         buttonApi.postActivity("test-activity", Collections.<ButtonProductCompatible>emptyList(),
-                null);
+                null, null);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
 
@@ -371,13 +371,14 @@ public class ButtonApiImplTest {
         ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
 
         buttonApi.postActivity("test-activity", Collections.<ButtonProductCompatible>emptyList(),
-                null);
+                "test-token", null);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
 
         assertEquals("test-activity", requestBody.getString("name"));
         assertEquals(0, requestBody.getJSONArray("products").length());
+        assertEquals("test-token", requestBody.getString("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
 
@@ -394,7 +395,7 @@ public class ButtonApiImplTest {
         buttonApi.postActivity("test-activity", new ArrayList<ButtonProductCompatible>() {{
             add(productOne);
             add(productTwo);
-        }}, null);
+        }}, "test-token", null);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
@@ -403,6 +404,7 @@ public class ButtonApiImplTest {
         assertEquals(2, requestBody.getJSONArray("products").length());
         assertEquals("one", requestBody.getJSONArray("products").getJSONObject(0).getString("id"));
         assertEquals("two", requestBody.getJSONArray("products").getJSONObject(1).getString("id"));
+        assertEquals("test-token", requestBody.getString("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
 
@@ -411,7 +413,7 @@ public class ButtonApiImplTest {
         ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
         ButtonProductCompatible product = new ButtonProduct();
 
-        buttonApi.postActivity("test-activity", Collections.singletonList(product), null);
+        buttonApi.postActivity("test-activity", Collections.singletonList(product), null, null);
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
@@ -419,6 +421,7 @@ public class ButtonApiImplTest {
         assertEquals("test-activity", requestBody.getString("name"));
         assertEquals(1, requestBody.getJSONArray("products").length());
         assertEquals(0, requestBody.getJSONArray("products").getJSONObject(0).length());
+        assertFalse(requestBody.has("btn_ref"));
         assertFalse(requestBody.has("ifa"));
     }
 
@@ -444,12 +447,13 @@ public class ButtonApiImplTest {
 
         buttonApi.postActivity("test-activity", new ArrayList<ButtonProductCompatible>() {{
             add(product);
-        }}, "test-ifa");
+        }}, "test-token", "test-ifa");
         verify(connectionManager).executeRequest(argumentCaptor.capture());
         ApiRequest apiRequest = argumentCaptor.getValue();
         JSONObject requestBody = apiRequest.getBody();
 
         assertEquals("test-ifa", requestBody.getString("ifa"));
+        assertEquals("test-token", requestBody.getString("btn_ref"));
         assertEquals("test-activity", requestBody.getString("name"));
         assertEquals(1, requestBody.getJSONArray("products").length());
         JSONObject productJson = requestBody.getJSONArray("products").getJSONObject(0);

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -91,15 +91,11 @@ public class ButtonMerchantTest {
     @Test
     public void configure_verifyFlushActivityQueue() {
         ButtonMerchant.activity = spy(ButtonMerchant.activity);
-        ButtonProductCompatible product = mock(ButtonProductCompatible.class);
 
-        ButtonMerchant.activity().productViewed(product);
-        ButtonMerchant.activity().productViewed(product);
-        ButtonMerchant.activity().productViewed(product);
         ButtonMerchant.configure(context, "invalid_application_id");
 
-        verify((ButtonUserActivityImpl) ButtonMerchant.activity).flushQueue(
-                any(ButtonRepository.class));
+        verify((ButtonUserActivityImpl) ButtonMerchant.activity)
+                .flushQueue(any(ButtonRepository.class));
     }
 
     @Test

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -85,6 +86,20 @@ public class ButtonMerchantTest {
     public void configure_verifyButtonInternal() {
         ButtonMerchant.configure(context, "valid_application_id");
         verify(buttonInternal).configure(any(ButtonRepository.class), eq("valid_application_id"));
+    }
+
+    @Test
+    public void configure_verifyFlushActivityQueue() {
+        ButtonMerchant.activity = spy(ButtonMerchant.activity);
+        ButtonProductCompatible product = mock(ButtonProductCompatible.class);
+
+        ButtonMerchant.activity().productViewed(product);
+        ButtonMerchant.activity().productViewed(product);
+        ButtonMerchant.activity().productViewed(product);
+        ButtonMerchant.configure(context, "invalid_application_id");
+
+        verify((ButtonUserActivityImpl) ButtonMerchant.activity).flushQueue(
+                any(ButtonRepository.class));
     }
 
     @Test
@@ -165,4 +180,8 @@ public class ButtonMerchantTest {
         assertTrue(ButtonMerchant.features() instanceof FeaturesImpl);
     }
 
+    @Test
+    public void activity_verifyInstanceType() {
+        assertTrue(ButtonMerchant.activity() instanceof ButtonUserActivityImpl);
+    }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonProductTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonProductTest.java
@@ -1,0 +1,114 @@
+/*
+ * ButtonProductTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ButtonProductTest {
+
+    private ButtonProduct product;
+
+    @Before
+    public void setUp() {
+        product = new ButtonProduct();
+    }
+
+    @Test
+    public void testGetSetId() {
+        product.setId("test-id");
+
+        assertEquals("test-id", ((ButtonProductCompatible) product).getId());
+    }
+
+    @Test
+    public void testGetSetUpc() {
+        product.setUpc("test-upc");
+
+        assertEquals("test-upc", ((ButtonProductCompatible) product).getUpc());
+    }
+
+    @Test
+    public void testGetSetCategories() {
+        List<String> categories = new ArrayList<>();
+        categories.add("category-one");
+        categories.add("category-two");
+        product.setCategories(categories);
+
+        assertEquals(categories, ((ButtonProductCompatible) product).getCategories());
+    }
+
+    @Test
+    public void testGetSetName() {
+        product.setName("test-name");
+
+        assertEquals("test-name", ((ButtonProductCompatible) product).getName());
+    }
+
+    @Test
+    public void testGetSetCurrency() {
+        product.setCurrency("test-code");
+
+        assertEquals("test-code", ((ButtonProductCompatible) product).getCurrency());
+    }
+
+    @Test
+    public void testGetSetValue() {
+        product.setValue(123);
+
+        assertEquals(new Integer(123), ((ButtonProductCompatible) product).getValue());
+    }
+
+    @Test
+    public void testGetSetQuantity() {
+        product.setQuantity(321);
+
+        assertEquals(new Integer(321), ((ButtonProductCompatible) product).getQuantity());
+    }
+
+    @Test
+    public void testGetSetUrl() {
+        product.setUrl("test-url");
+
+        assertEquals("test-url", ((ButtonProductCompatible) product).getUrl());
+    }
+
+    @Test
+    public void testGetSetAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("key", "value");
+        product.setAttributes(attributes);
+
+        assertEquals(attributes, ((ButtonProductCompatible) product).getAttributes());
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonUserActivityImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonUserActivityImplTest.java
@@ -1,0 +1,215 @@
+/*
+ * ButtonUserActivityImplTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import com.usebutton.merchant.module.ButtonUserActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ButtonUserActivityImplTest {
+
+    private ButtonRepository buttonRepository;
+    private ButtonUserActivity activityModule;
+
+    @Before
+    public void setUp() throws Exception {
+        buttonRepository = mock(ButtonRepository.class);
+        activityModule = new ButtonUserActivityImpl();
+    }
+
+    @Test
+    public void productViewed_repositoryUnavailable_shouldQueueActivityEvent() {
+        activityModule.productViewed(null);
+        activityModule.productViewed(null);
+
+        assertEquals(2, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_PRODUCT_VIEWED),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+    }
+
+    @Test
+    public void productViewed_repositoryAvailable_shouldTrackActivity() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productViewed(null);
+        activityModule.productViewed(null);
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_PRODUCT_VIEWED),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+    }
+
+    @Test
+    public void productViewed_nullProduct_shouldTrackWithEmptyList() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productViewed(null);
+
+        verify(buttonRepository).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_PRODUCT_VIEWED),
+                eq(new ArrayList<ButtonProductCompatible>())
+        );
+    }
+
+    @Test
+    public void productViewed_validProduct_shouldTrackWithProductInList() {
+        ButtonProductCompatible product = new ButtonProduct();
+        List<ButtonProductCompatible> products = new ArrayList<>();
+        products.add(product);
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productViewed(product);
+
+        verify(buttonRepository).trackActivity(ButtonUserActivityImpl.EVENT_PRODUCT_VIEWED,
+                products);
+    }
+
+    @Test
+    public void productAddedToCart_repositoryUnavailable_shouldQueueActivityEvent() {
+        activityModule.productAddedToCart(null);
+        activityModule.productAddedToCart(null);
+
+        assertEquals(2, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_ADD_TO_CART),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+    }
+
+    @Test
+    public void productAddedToCart_repositoryAvailable_shouldTrackActivity() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productAddedToCart(null);
+        activityModule.productAddedToCart(null);
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_ADD_TO_CART),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+    }
+
+    @Test
+    public void productAddedToCart_nullProduct_shouldTrackWithEmptyList() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productAddedToCart(null);
+
+        verify(buttonRepository).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_ADD_TO_CART),
+                eq(new ArrayList<ButtonProductCompatible>())
+        );
+    }
+
+    @Test
+    public void productAddedToCart_validProduct_shouldTrackWithProductInList() {
+        ButtonProductCompatible product = new ButtonProduct();
+        List<ButtonProductCompatible> products = new ArrayList<>();
+        products.add(product);
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.productAddedToCart(product);
+
+        verify(buttonRepository).trackActivity(ButtonUserActivityImpl.EVENT_ADD_TO_CART,
+                products);
+    }
+
+    @Test
+    public void cartViewed_repositoryUnavailable_shouldQueueActivityEvent() {
+        activityModule.cartViewed(null);
+        activityModule.cartViewed(null);
+
+        assertEquals(2, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_CART_VIEWED),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+    }
+
+    @Test
+    public void cartViewed_repositoryAvailable_shouldTrackActivity() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.cartViewed(null);
+        activityModule.cartViewed(null);
+        assertEquals(0, ((ButtonUserActivityImpl) activityModule).queuedActivityEvents.size());
+
+        verify(buttonRepository, times(2)).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_CART_VIEWED),
+                ArgumentMatchers.<ButtonProductCompatible>anyList()
+        );
+    }
+
+    @Test
+    public void cartViewed_nullProductList_shouldTrackWithEmptyList() {
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.cartViewed(null);
+
+        verify(buttonRepository).trackActivity(
+                eq(ButtonUserActivityImpl.EVENT_CART_VIEWED),
+                eq(new ArrayList<ButtonProductCompatible>())
+        );
+    }
+
+    @Test
+    public void cartViewed_validProductList_shouldTrackWithProductList() {
+        ButtonProductCompatible product = new ButtonProduct();
+        List<ButtonProductCompatible> products = new ArrayList<>();
+        products.add(product);
+        ((ButtonUserActivityImpl) activityModule).flushQueue(buttonRepository);
+
+        activityModule.cartViewed(products);
+
+        verify(buttonRepository).trackActivity(ButtonUserActivityImpl.EVENT_CART_VIEWED,
+                products);
+    }
+}

--- a/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
+++ b/sample/src/main/java/com/usebutton/merchant/sample/KotlinActivity.kt
@@ -12,7 +12,10 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import com.usebutton.merchant.ButtonMerchant
+import com.usebutton.merchant.ButtonProduct
+import com.usebutton.merchant.ButtonProductCompatible
 import com.usebutton.merchant.Order
+import com.usebutton.merchant.sample.R.id
 import java.util.Collections
 import java.util.Date
 import java.util.Locale
@@ -37,6 +40,7 @@ class KotlinActivity : AppCompatActivity() {
         checkForPostInstallIntent()
         initTrackNewIntentButton()
         initTrackOrderButton()
+        initActivityButtons();
         initClearDataButton()
         initAttributionTokenListener()
         initReportOrderButton()
@@ -119,6 +123,20 @@ class KotlinActivity : AppCompatActivity() {
         }
     }
 
+    private fun initActivityButtons() {
+        findViewById<View>(id.track_product_viewed).setOnClickListener {
+            ButtonMerchant.activity().productViewed(product)
+        }
+
+        findViewById<View>(id.track_add_cart).setOnClickListener {
+            ButtonMerchant.activity().productAddedToCart(product)
+        }
+
+        findViewById<View>(id.track_cart_viewed).setOnClickListener {
+            ButtonMerchant.activity().cartViewed(listOf(product, product))
+        }
+    }
+
     private fun initClearDataButton() {
         findViewById<View>(R.id.clear_all_data).setOnClickListener {
             ButtonMerchant.clearAllData(this)
@@ -147,6 +165,17 @@ class KotlinActivity : AppCompatActivity() {
         private var TEST_URL = String.format(Locale.getDefault(),
                 "https://example.com/p/123?btn_ref=srctok-abc%d&from_landing=true&from_tracking=false&btn_blargh=blergh&other_param=some_val",
                 Random().nextInt(100000))
+        private val product: ButtonProductCompatible = ButtonProduct().apply {
+            id = "prod-123"
+            upc = "1234567890"
+            categories = listOf("daily-deals", "black-friday")
+            name = "Sample Product"
+            currency = "USD"
+            value = 129900
+            quantity = 1
+            url = "https://www.bestbuy.com/site/samsung-65-class-qled-q70-series-4k-uhd-tv-smart-led-with-hdr/6402399.p?skuId=6402399"
+            attributes = mapOf(Pair("size", "large"), Pair("in_stock", "true"))
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -41,13 +41,17 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.usebutton.merchant.ButtonMerchant;
+import com.usebutton.merchant.ButtonProduct;
+import com.usebutton.merchant.ButtonProductCompatible;
 import com.usebutton.merchant.Order;
 import com.usebutton.merchant.OrderListener;
 import com.usebutton.merchant.PostInstallIntentListener;
 import com.usebutton.merchant.UserActivityListener;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -163,6 +167,30 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
+        findViewById(R.id.track_product_viewed).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ButtonMerchant.activity().productViewed(getProduct());
+            }
+        });
+
+        findViewById(R.id.track_add_cart).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ButtonMerchant.activity().productAddedToCart(getProduct());
+            }
+        });
+
+        findViewById(R.id.track_cart_viewed).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                List<ButtonProductCompatible> products = new ArrayList<>();
+                products.add(getProduct());
+                products.add(getProduct());
+                ButtonMerchant.activity().cartViewed(products);
+            }
+        });
+
         findViewById(R.id.clear_all_data).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -225,5 +253,30 @@ public class MainActivity extends AppCompatActivity {
                 break;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private static ButtonProductCompatible getProduct() {
+        ButtonProduct product = new ButtonProduct();
+
+        List<String> categories = new ArrayList<>();
+        categories.add("daily-deals");
+        categories.add("black-friday");
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("size", "large");
+        attributes.put("in_stock", "true");
+
+        product.setId("prod-123");
+        product.setUpc("1234567890");
+        product.setCategories(categories);
+        product.setName("Sample Product");
+        product.setCurrency("USD");
+        product.setValue(129900);
+        product.setQuantity(1);
+        product.setUrl(
+                "https://www.bestbuy.com/site/samsung-65-class-qled-q70-series-4k-uhd-tv-smart-led-with-hdr/6402399.p?skuId=6402399");
+        product.setAttributes(attributes);
+
+        return product;
     }
 }

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -273,8 +273,8 @@ public class MainActivity extends AppCompatActivity {
         product.setCurrency("USD");
         product.setValue(129900);
         product.setQuantity(1);
-        product.setUrl(
-                "https://www.bestbuy.com/site/samsung-65-class-qled-q70-series-4k-uhd-tv-smart-led-with-hdr/6402399.p?skuId=6402399");
+        product.setUrl("https://www.bestbuy.com/site/samsung-65-class-qled-q70-series-4k-uhd-tv-sm"
+                + "art-led-with-hdr/6402399.p?skuId=6402399");
         product.setAttributes(attributes);
 
         return product;

--- a/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
+++ b/sample/src/main/java/com/usebutton/merchant/sample/MainActivity.java
@@ -170,7 +170,7 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.track_product_viewed).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ButtonMerchant.activity().productViewed(getProduct());
+                ButtonMerchant.activity().productViewed(null);
             }
         });
 

--- a/sample/src/main/res/layout/content_main.xml
+++ b/sample/src/main/res/layout/content_main.xml
@@ -50,6 +50,13 @@
         />
 
     <Button
+        android:id="@+id/track_new_intent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Track New Intent"
+        />
+
+    <Button
         android:id="@+id/track_order"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -64,17 +71,31 @@
         />
 
     <Button
+        android:id="@+id/track_product_viewed"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Track Product Viewed"
+        />
+
+    <Button
+        android:id="@+id/track_add_cart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Track Add To Cart"
+        />
+
+    <Button
+        android:id="@+id/track_cart_viewed"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Track Cart Viewed"
+        />
+
+    <Button
         android:id="@+id/clear_all_data"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Clear All Data"
-        />
-
-    <Button
-        android:id="@+id/track_new_intent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Track New Intent"
         />
 
 </LinearLayout>


### PR DESCRIPTION
### Goals :soccer:
To allow a Brand to report key points of a user's shopping journey within their application.

### Implementation :construction:
- API is available via a "module" -- `ButtonMerchant.activity().xxxxx()`
- As with all things data, the internal networking logic is available via `ButtonRepository`. However, since `ButtonRepository` requires `Context` to be initialized, it may not be available until the Brand calls `ButtonMerchant.configure(~)`. As such, until configuration occurs, the `ButtonUserActivityImpl` class queues up the calls. A call to `ButtonMerchant.configure(~)` flushes this queue and all subsequent calls to `ButtonMerchant.activity().xxxx()` will be reported immediately.
- If an _empty_ `ButtonProduct` is provided then it will still be reported as an empty JSON object. For example, if a cart has been viewed with two products then it'll be reported like so:
```
{
	"name": "cart-viewed",
	"products": [{}, {}]
}
```