### PR TITLE
Ensure event reports include IDs and timestamps

### DIFF
--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonApiImpl.java
@@ -36,6 +36,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -215,6 +216,7 @@ final class ButtonApiImpl implements ButtonApi {
 
             JSONObject requestBody = new JSONObject();
             requestBody.put("ifa", advertisingId);
+            requestBody.put("current_time", ButtonUtil.formatDate(new Date()));
             requestBody.put("events", eventStream);
 
             ApiRequest apiRequest = new ApiRequest.Builder(ApiRequest.RequestMethod.POST,

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonUtil.java
@@ -71,6 +71,14 @@ final class ButtonUtil {
         return simpleDateFormat.format(date);
     }
 
+    /**
+     * @param timestamp timestamp to be formatted
+     * @return date formatted in ISO_8601 format
+     */
+    public static String formatTimestamp(long timestamp) {
+        return formatDate(new Date(timestamp));
+    }
+
     public static String base64Encode(String value) {
         return Base64.encodeToString(value.getBytes(), Base64.NO_WRAP);
     }

--- a/button-merchant/src/main/java/com/usebutton/merchant/Event.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/Event.java
@@ -31,6 +31,8 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.UUID;
+
 /**
  * Internal class used to encapsulate event data.
  */
@@ -74,12 +76,16 @@ class Event {
         }
     }
 
+    private final UUID id;
+    private final long timestamp;
     private final Name name;
     @Nullable
     private final String sourceToken;
     private final JSONObject eventBody;
 
     Event(Name name, @Nullable String sourceToken) {
+        this.id = UUID.randomUUID();
+        this.timestamp = System.currentTimeMillis();
         this.name = name;
         this.sourceToken = sourceToken;
         this.eventBody = new JSONObject();
@@ -91,6 +97,14 @@ class Event {
         } catch (JSONException e) {
             Log.e(TAG, String.format("Error adding property [%s] to event [%s]", key, name), e);
         }
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
     }
 
     public Name getName() {
@@ -110,6 +124,8 @@ class Event {
         JSONObject json = new JSONObject();
         json.put("name", name.eventName);
         json.put("promotion_source_token", sourceToken);
+        json.put("time", ButtonUtil.formatTimestamp(timestamp));
+        json.put("uuid", id.toString());
         json.put("value", eventBody);
         return json;
     }

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonApiImplTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -408,5 +409,21 @@ public class ButtonApiImplTest {
         JSONObject requestBody = apiRequest.getBody();
 
         assertEquals(requestBody.getString("ifa"), "valid_ifa");
+    }
+
+    @Test
+    public void postEvents_shouldIncludeTimestamp() throws Exception {
+        ArgumentCaptor<ApiRequest> argumentCaptor = ArgumentCaptor.forClass(ApiRequest.class);
+        List<Event> events = new ArrayList<>();
+        Event event = new Event(Event.Name.DEEPLINK_OPENED, "valid_token");
+        events.add(event);
+
+        buttonApi.postEvents(events, null);
+
+        verify(connectionManager).executeRequest(argumentCaptor.capture());
+        ApiRequest apiRequest = argumentCaptor.getValue();
+        JSONObject requestBody = apiRequest.getBody();
+
+        assertTrue(requestBody.has("current_time"));
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/EventTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/EventTest.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class EventTest {
@@ -40,6 +41,8 @@ public class EventTest {
         assertEquals(Event.Name.DEEPLINK_OPENED, event.getName());
         assertEquals("valid_token", event.getSourceToken());
         assertEquals((new JSONObject()).toString(), event.getEventBody().toString());
+        assertNotNull(event.getId());
+        assertTrue(event.getTimestamp() > 0);
     }
 
     @Test


### PR DESCRIPTION
### Goals :soccer:
To ensure event reports include IDs and timestamps.

### Implementation :construction:
- Creation of an `Event` object will now generate a UUIDv4 compliant `id` and an ISO8601 compliant `time`
- The `/v1/app/events` request body will include an ISO8601 compliant `current_time` field indicating the time the request was made.
