### PR TITLE
Migrate MainThreadExecutorTest to instrumentation test; Remove Robolectric dependency

### DIFF
--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    testImplementation "org.robolectric:robolectric:3.8"
     testImplementation 'org.json:json:20171018'
     androidTestImplementation "com.android.support.test:runner:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"

--- a/button-merchant/src/androidTest/java/com/usebutton/merchant/MainThreadExecutorTest.java
+++ b/button-merchant/src/androidTest/java/com/usebutton/merchant/MainThreadExecutorTest.java
@@ -1,7 +1,7 @@
 /*
  * MainThreadExecutorTest.java
  *
- * Copyright (c) 2018 Button, Inc. (https://usebutton.com)
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,35 +26,34 @@
 package com.usebutton.merchant;
 
 import android.os.Looper;
+import android.support.test.InstrumentationRegistry;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(RobolectricTestRunner.class)
 public class MainThreadExecutorTest {
 
     private Executor executor = new MainThreadExecutor();
 
     @Test
-    public void executor_shouldExecute() throws Exception {
+    public void executor_shouldExecute() {
         final boolean[] executed = { false };
+        final Looper[] looper = { null };
 
         executor.execute(new Runnable() {
             @Override
             public void run() {
-                assertEquals(Looper.myLooper(), Looper.getMainLooper());
+                looper[0] = Looper.myLooper();
                 executed[0] = true;
             }
         });
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 
-        Robolectric.flushForegroundThreadScheduler();
+        assertEquals(Looper.getMainLooper(), looper[0]);
         assertTrue(executed[0]);
     }
 }


### PR DESCRIPTION
### Goals :soccer:
To setup the first instrumentation test of the project and to remove the Robolectric dependency as it will no longer be needed
