### PR TITLE
Added Brand Test Runner support

### DIFF
--- a/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
+++ b/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
@@ -1,0 +1,190 @@
+/*
+ * TestManagerTest.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class TestManagerTest {
+
+    private Context context;
+    private ButtonRepository buttonRepository;
+    private TestManager.Terminator terminator;
+    private TestManager testManager;
+    private ArgumentCaptor<Intent> intentCaptor;
+
+    @Before
+    public void setUp() {
+        context = mock(Context.class, RETURNS_MOCKS);
+        buttonRepository = mock(ButtonRepository.class);
+        terminator = mock(TestManager.Terminator.class);
+        testManager = new TestManager(context, buttonRepository, terminator);
+        intentCaptor = ArgumentCaptor.forClass(Intent.class);
+    }
+
+    @Test
+    public void parseIntent_unrecognized_shouldNotSendResponse() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("test://hello/world"));
+
+        testManager.parseIntent(intent);
+
+        verifyZeroInteractions(context);
+    }
+
+    @Test
+    public void parseIntent_unsupported_shouldNotSendResponse() {
+        Intent intent = createIntentForAction("unknown");
+
+        testManager.parseIntent(intent);
+
+        verifyZeroInteractions(context);
+    }
+
+    @Test
+    public void parseIntent_quit_harnessExists_shouldQuitApp() {
+        Intent intent = createIntentForAction(TestManager.ACTION_QUIT);
+
+        testManager.parseIntent(intent);
+
+        verifyBaseResponseStructure(TestManager.ACTION_QUIT);
+        verify(terminator).terminate();
+    }
+
+    @Test
+    public void parseIntent_quit_harnessDoesNotExist_shouldNotQuitApp() {
+        Intent intent = createIntentForAction(TestManager.ACTION_QUIT);
+        doThrow(ActivityNotFoundException.class).when(context).startActivity(any(Intent.class));
+
+        testManager.parseIntent(intent);
+
+        verify(terminator, never()).terminate();
+    }
+
+    @Test
+    public void parseIntent_getToken_nullToken_shouldSendTokenInResponse() {
+        Intent intent = createIntentForAction(TestManager.ACTION_GET_TOKEN);
+        when(buttonRepository.getSourceToken()).thenReturn(null);
+
+        testManager.parseIntent(intent);
+
+        Uri data = verifyBaseResponseStructure(TestManager.ACTION_GET_TOKEN);
+        assertEquals("null", data.getQueryParameter("btn_ref"));
+    }
+
+    @Test
+    public void parseIntent_getToken_validToken_shouldSendTokenInResponse() {
+        Intent intent = createIntentForAction(TestManager.ACTION_GET_TOKEN);
+        when(buttonRepository.getSourceToken()).thenReturn("test-token");
+
+        testManager.parseIntent(intent);
+
+        Uri data = verifyBaseResponseStructure(TestManager.ACTION_GET_TOKEN);
+        assertEquals("test-token", data.getQueryParameter("btn_ref"));
+    }
+
+    @Test
+    public void parseIntent_postInstall_shouldSendResultInResponse() {
+        Intent intent = createIntentForAction(TestManager.ACTION_POST_INSTALL);
+        when(buttonRepository.checkedDeferredDeepLink()).thenReturn(true);
+
+        testManager.parseIntent(intent);
+
+        Uri data = verifyBaseResponseStructure(TestManager.ACTION_POST_INSTALL);
+        assertEquals("true", data.getQueryParameter("success"));
+    }
+
+    @Test
+    public void parseIntent_version_shouldSendVersionInResponse() {
+        Intent intent = createIntentForAction(TestManager.ACTION_VERSION);
+
+        testManager.parseIntent(intent);
+
+        Uri data = verifyBaseResponseStructure(TestManager.ACTION_VERSION);
+        assertEquals(BuildConfig.VERSION_NAME, data.getQueryParameter("version"));
+    }
+
+    @Test
+    public void parseIntent_echo_true_shouldSendTokenInResponse() {
+        Uri uri = Uri.parse("test://this/is/different?with_different=params&btn_test_echo=true");
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        when(buttonRepository.getSourceToken()).thenReturn("test-token");
+
+        testManager.parseIntent(intent);
+
+        Uri data = verifyBaseResponseStructure(TestManager.ACTION_ECHO_TOKEN);
+        assertEquals("test-token", data.getQueryParameter("btn_ref"));
+    }
+
+    @Test
+    public void parseIntent_echo_false_shouldNotSendResponse() {
+        Uri uri = Uri.parse("test://this/is/different?with_different=params&btn_test_echo=false");
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        when(buttonRepository.getSourceToken()).thenReturn("test-token");
+
+        testManager.parseIntent(intent);
+
+        verifyZeroInteractions(context);
+    }
+
+    private static Intent createIntentForAction(String action) {
+        Uri uri = Uri.parse(String.format("test://home/action/%s", action));
+        return new Intent(Intent.ACTION_VIEW, uri);
+    }
+
+    private Uri verifyBaseResponseStructure(String actionType) {
+        verify(context).startActivity(intentCaptor.capture());
+
+        Intent intent = intentCaptor.getValue();
+        assertNotNull(intent);
+        assertEquals(TestManager.TEST_HARNESS_PACKAGE, intent.getPackage());
+        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, intent.getFlags());
+
+        Uri data = intent.getData();
+        assertNotNull(data);
+        assertEquals(TestManager.TEST_HARNESS_SCHEME, data.getScheme());
+        assertEquals(TestManager.ACTION_RESPONSE, data.getAuthority());
+        assertEquals("/" + actionType, data.getPath());
+
+        return data;
+    }
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternal.java
@@ -41,8 +41,8 @@ interface ButtonInternal {
     @Nullable
     String getApplicationId(ButtonRepository buttonRepository);
 
-    void trackIncomingIntent(ButtonRepository buttonRepository, DeviceManager deviceManager,
-            Features features, Intent intent);
+    void trackIncomingIntent(TestManager testManager, ButtonRepository buttonRepository,
+            DeviceManager deviceManager, Features features, Intent intent);
 
     @Nullable
     String getAttributionToken(ButtonRepository buttonRepository);

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonInternalImpl.java
@@ -93,8 +93,8 @@ final class ButtonInternalImpl implements ButtonInternal {
     }
 
     @Override
-    public void trackIncomingIntent(ButtonRepository buttonRepository, DeviceManager deviceManager,
-            Features features, Intent intent) {
+    public void trackIncomingIntent(TestManager testManager, ButtonRepository buttonRepository,
+            DeviceManager deviceManager, Features features, Intent intent) {
         Uri data = intent.getData();
         if (data == null) {
             return;
@@ -106,6 +106,7 @@ final class ButtonInternalImpl implements ButtonInternal {
             hasReceivedDirectDeeplink.set(true);
         }
 
+        testManager.parseIntent(intent);
         reportDeeplinkOpenEvent(buttonRepository, deviceManager, features, data);
     }
 

--- a/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/ButtonMerchant.java
@@ -77,8 +77,10 @@ public final class ButtonMerchant {
      * @param intent An intent that has entered your app from a third party source.
      */
     public static void trackIncomingIntent(@NonNull Context context, @NonNull Intent intent) {
-        buttonInternal.trackIncomingIntent(getButtonRepository(context), getDeviceManager(context),
-                features(), intent);
+        TestManager testManager = new TestManager(context, getButtonRepository(context),
+                new TestManager.Terminator());
+        buttonInternal.trackIncomingIntent(testManager, getButtonRepository(context),
+                getDeviceManager(context), features(), intent);
     }
 
     /**

--- a/button-merchant/src/main/java/com/usebutton/merchant/TestManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/TestManager.java
@@ -1,0 +1,158 @@
+/*
+ * TestManager.java
+ *
+ * Copyright (c) 2020 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.List;
+
+/**
+ * Internal class responsible for assisting in test automation.
+ */
+class TestManager {
+
+    @VisibleForTesting static final String TEST_HARNESS_SCHEME = "button-brand-test";
+    @VisibleForTesting static final String TEST_HARNESS_PACKAGE = "com.usebutton.brandtest";
+
+    @VisibleForTesting static final String ACTION_QUIT = "quit";
+    @VisibleForTesting static final String ACTION_GET_TOKEN = "get-token";
+    @VisibleForTesting static final String ACTION_ECHO_TOKEN = "echo";
+    @VisibleForTesting static final String ACTION_POST_INSTALL = "test-post-install";
+    @VisibleForTesting static final String ACTION_VERSION = "version";
+    @VisibleForTesting static final String ACTION_RESPONSE = "action-response";
+
+    private final Context context;
+    private final ButtonRepository buttonRepository;
+    private final Terminator terminator;
+
+    TestManager(Context context, ButtonRepository buttonRepository, Terminator terminator) {
+        this.context = context;
+        this.buttonRepository = buttonRepository;
+        this.terminator = terminator;
+    }
+
+    public void parseIntent(Intent intent) {
+        Uri data = intent.getData();
+        if (data == null) {
+            return;
+        }
+
+        String echoParam = data.getQueryParameter("btn_test_echo");
+        List<String> segments = data.getPathSegments();
+        if (segments != null && segments.size() == 2 && "action".equals(segments.get(0))) {
+            String action = segments.get(1);
+            switch (action) {
+                case ACTION_QUIT:
+                    quit();
+                    break;
+                case ACTION_GET_TOKEN:
+                    sendToken(ACTION_GET_TOKEN);
+                    break;
+                case ACTION_POST_INSTALL:
+                    sendPostInstallerResult();
+                    break;
+                case ACTION_VERSION:
+                    sendLibraryVersion();
+                    break;
+                default:
+                    break;
+            }
+        } else if ("true".equals(echoParam)) {
+            sendToken(ACTION_ECHO_TOKEN);
+        }
+    }
+
+    private void quit() {
+        Uri responseDeeplink = new Uri.Builder()
+                .scheme(TEST_HARNESS_SCHEME)
+                .authority(ACTION_RESPONSE)
+                .appendPath(ACTION_QUIT)
+                .build();
+        boolean successful = submitResult(responseDeeplink);
+
+        if (successful) {
+            terminator.terminate();
+        }
+    }
+
+    private void sendToken(String requestSource) {
+        String token = buttonRepository.getSourceToken();
+        Uri responseDeeplink = new Uri.Builder()
+                .scheme(TEST_HARNESS_SCHEME)
+                .authority(ACTION_RESPONSE)
+                .appendPath(requestSource)
+                .appendQueryParameter("btn_ref", token)
+                .build();
+        submitResult(responseDeeplink);
+    }
+
+    private void sendPostInstallerResult() {
+        boolean checked = buttonRepository.checkedDeferredDeepLink();
+        Uri responseDeeplink = new Uri.Builder()
+                .scheme(TEST_HARNESS_SCHEME)
+                .authority(ACTION_RESPONSE)
+                .appendPath(ACTION_POST_INSTALL)
+                .appendQueryParameter("success", String.valueOf(checked))
+                .build();
+        submitResult(responseDeeplink);
+    }
+
+    private void sendLibraryVersion() {
+        Uri responseDeeplink = new Uri.Builder()
+                .scheme(TEST_HARNESS_SCHEME)
+                .authority(ACTION_RESPONSE)
+                .appendPath(ACTION_VERSION)
+                .appendQueryParameter("version", BuildConfig.VERSION_NAME)
+                .build();
+        submitResult(responseDeeplink);
+    }
+
+    private boolean submitResult(Uri result) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, result);
+        intent.setPackage(TEST_HARNESS_PACKAGE);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        try {
+            context.startActivity(intent);
+            return true;
+        } catch (ActivityNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Internal class responsible for terminating the host application.
+     */
+    static class Terminator {
+        void terminate() {
+            android.os.Process.killProcess(android.os.Process.myPid());
+        }
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonInternalImplTest.java
@@ -93,8 +93,8 @@ public class ButtonInternalImplTest {
         when(builder.build()).thenReturn(uri);
         when(uri.getQueryParameter("btn_ref")).thenReturn("valid_source_token");
 
-        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
-                mock(Features.class), intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository,
+                mock(DeviceManager.class), mock(Features.class), intent);
 
         verify(buttonRepository).setSourceToken("valid_source_token");
     }
@@ -105,10 +105,28 @@ public class ButtonInternalImplTest {
         Intent intent = mock(Intent.class);
         when(intent.getData()).thenReturn(null);
 
-        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
-                mock(Features.class), intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository,
+                mock(DeviceManager.class), mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken(anyString());
+    }
+
+    @Test
+    public void trackIncomingIntent_shouldPassIntentToTestManager() {
+        TestManager testManager = mock(TestManager.class);
+        Intent intent = mock(Intent.class);
+        Uri uri = mock(Uri.class);
+        Uri.Builder builder = mock(Uri.Builder.class);
+        when(intent.getData()).thenReturn(uri);
+        when(uri.buildUpon()).thenReturn(builder);
+        when(uri.buildUpon().clearQuery()).thenReturn(builder);
+        when(builder.build()).thenReturn(uri);
+        when(uri.getQueryParameter("btn_ref")).thenReturn("valid_source_token");
+
+        buttonInternal.trackIncomingIntent(testManager, mock(ButtonRepository.class),
+                mock(DeviceManager.class), mock(Features.class), intent);
+
+        verify(testManager).parseIntent(intent);
     }
 
     @Test
@@ -128,8 +146,8 @@ public class ButtonInternalImplTest {
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
-                mock(Features.class), intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository,
+                mock(DeviceManager.class), mock(Features.class), intent);
 
         verify(buttonRepository).setSourceToken(validToken);
         verify(listener).onAttributionTokenChanged(validToken);
@@ -151,8 +169,8 @@ public class ButtonInternalImplTest {
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
-                mock(Features.class), intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository,
+                mock(DeviceManager.class), mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken(null);
         verify(listener, never()).onAttributionTokenChanged(null);
@@ -174,8 +192,8 @@ public class ButtonInternalImplTest {
         ButtonMerchant.AttributionTokenListener listener =
                 mock(ButtonMerchant.AttributionTokenListener.class);
         buttonInternal.addAttributionTokenListener(buttonRepository, listener);
-        buttonInternal.trackIncomingIntent(buttonRepository, mock(DeviceManager.class),
-                mock(Features.class), intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository,
+                mock(DeviceManager.class), mock(Features.class), intent);
 
         verify(buttonRepository, never()).setSourceToken("");
         verify(listener, never()).onAttributionTokenChanged("");
@@ -386,7 +404,8 @@ public class ButtonInternalImplTest {
                 new PostInstallLink(true, "ddl-6faffd3451edefd3", "uber://asdfasfasf",
                         attribution);
 
-        buttonInternal.trackIncomingIntent(buttonRepository, deviceManager, features, intent);
+        buttonInternal.trackIncomingIntent(mock(TestManager.class), buttonRepository, deviceManager,
+                features, intent);
         buttonInternal.handlePostInstallIntent(buttonRepository, deviceManager,
                 features, "com.usebutton.merchant", postInstallIntentListener);
 

--- a/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/ButtonMerchantTest.java
@@ -101,8 +101,9 @@ public class ButtonMerchantTest {
     @Test
     public void trackIncomingIntent_verifyButtonInternal() {
         ButtonMerchant.trackIncomingIntent(context, mock(Intent.class));
-        verify(buttonInternal).trackIncomingIntent(any(ButtonRepository.class),
-                any(DeviceManager.class), any(Features.class), any(Intent.class));
+        verify(buttonInternal).trackIncomingIntent(any(TestManager.class),
+                any(ButtonRepository.class), any(DeviceManager.class), any(Features.class),
+                any(Intent.class));
     }
 
     @Test


### PR DESCRIPTION
### Goals :soccer:
To setup a framework that will allow us to automate much of the manual QA process for new integrations.

### Implementation :construction:
Added a `TestManager` class that has only one public method `parseIntent(~)`. This method will be called whenever `ButtonMerchant.trackIncomingIntent(~)` is called. The `TestManager` will parse the Intent for testing instructions. If found, it will execute the requested action and send the response **only** to the Brand Test Runner app. If the action is unsupported or if the app is not available on the device then no response will be sent anywhere.
