### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,8 @@ subprojects {
 ext {
     supportLibVersion = '27.1.1'
     playServicesVersion = '15.0.0'
-    junitVersion = '4.12'
-    mockitoVersion = '2.16.0'
+    junitVersion = '4.13.1'
+    mockitoVersion = '2.28.2'
     espressoVersion = '3.0.2'
     testRunnerVersion = '1.0.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ subprojects {
 }
 
 ext {
-    supportLibVersion = '27.1.1'
+    supportLibVersion = '28.0.0'
     playServicesVersion = '15.0.0'
     junitVersion = '4.13.1'
     mockitoVersion = '2.28.2'

--- a/build.gradle
+++ b/build.gradle
@@ -26,18 +26,19 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.4.10'
 
     repositories {
         google()
         jcenter()
+        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.5-SNAPSHOT'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -35,7 +35,6 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 15
@@ -72,7 +71,7 @@ task javadocJar(type: Jar, dependsOn: "generateReleaseJavadoc") {
 android.libraryVariants.all { variant ->
 
     task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
-        source = variant.javaCompile.source
+        source = variant.javaCompileProvider.get().source
         title = null
         List<File> pathList = new ArrayList<File>()
         pathList.add(file('./doclava-1.0.6.jar'))
@@ -164,9 +163,9 @@ task jacocoReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
     def mainSrc = "${project.projectDir}/src/main/java"
 
-    sourceDirectories = files([mainSrc])
-    classDirectories = files([debugTree])
-    executionData = fileTree(dir: "$buildDir", includes: [
+    sourceDirectories.setFrom files([mainSrc])
+    classDirectories.setFrom files([debugTree])
+    executionData.setFrom fileTree(dir: "$buildDir", includes: [
             "jacoco/testDebugUnitTest.exec",
             "outputs/code-coverage/connected/*coverage.ec"
     ])

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -34,11 +34,11 @@ version = libraryVersionName
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName version
 

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -105,8 +105,8 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    testImplementation 'org.json:json:20171018'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.4.0'
+    testImplementation 'org.json:json:20180813'
     androidTestImplementation "com.android.support.test:runner:$testRunnerVersion"
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -15,15 +15,21 @@
     </module>
 
     <!-- Space after 'for' and 'if' -->
-        <module name="RegexpSingleline">
-        <property name="format" value="^\s*(for|if)[^ ]\("/>
-        <property name="message" value="Space needed before opening parenthesis."/>
+    <module name="RegexpSingleline">
+        <property name="format" value="^\s*(for|if)[^ ]\(" />
+        <property name="message" value="Space needed before opening parenthesis." />
     </module>
 
     <!-- For each spacing -->
     <module name="RegexpSingleline">
-        <property name="format" value="^\s*for \(.*?([^ ]:|:[^ ])"/>
-        <property name="message" value="Space needed around ':' character."/>
+        <property name="format" value="^\s*for \(.*?([^ ]:|:[^ ])" />
+        <property name="message" value="Space needed around ':' character." />
+    </module>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+        <property name="max" value="100" />
     </module>
 
     <module name="TreeWalker">
@@ -32,7 +38,7 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <!--module name="JavadocMethod"/-->
-        <module name="JavadocType"/>
+        <module name="JavadocType" />
         <!--module name="JavadocVariable"/-->
         <!--module name="JavadocStyle"/-->
 
@@ -62,11 +68,6 @@
         </module>
 
 
-        <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="100"/>
-        </module>
         <module name="MethodLength">
             <property name="max" value="200"/>
         </module>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -23,9 +23,9 @@
 #
 #
 
-#Sun Mar 04 13:50:40 EST 2018
+#Fri Oct 23 16:09:18 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,7 +31,6 @@ def BUTTON_MERCHANT_API_KEY = hasProperty('buttonMerchantAppId') ? '"' + buttonM
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.usebutton.merchant.sample"


### PR DESCRIPTION
This PR serves to bring our Gradle tooling as well as many of our test dependencies up to date. Additionally, this PR also bumps the _target_ API from 27 to 28.