### PR TITLE
<Test Helper> Close app by finishing task

### DIFF
--- a/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
+++ b/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
@@ -37,6 +37,8 @@ import org.mockito.ArgumentCaptor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -87,7 +89,7 @@ public class TestManagerTest {
         testManager.parseIntent(intent);
 
         verifyBaseResponseStructure(TestManager.ACTION_QUIT);
-        verify(terminator).terminate();
+        verify(terminator).terminate(eq(context), anyBoolean());
     }
 
     @Test
@@ -97,7 +99,29 @@ public class TestManagerTest {
 
         testManager.parseIntent(intent);
 
-        verify(terminator, never()).terminate();
+        verify(terminator, never()).terminate(eq(context), anyBoolean());
+    }
+
+    @Test
+    public void parseIntent_quit_noForceQuit_shouldNotForceQuit() {
+        Intent intent = createIntentForAction(TestManager.ACTION_QUIT);
+
+        testManager.parseIntent(intent);
+
+        verifyBaseResponseStructure(TestManager.ACTION_QUIT);
+        verify(terminator).terminate(context, false);
+    }
+
+    @Test
+    public void parseIntent_quit_forceQuit_shouldForceQuit() {
+        Uri uri = Uri.parse(String.format("test://home/action/%s?should_force_quit=true",
+                TestManager.ACTION_QUIT));
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+
+        testManager.parseIntent(intent);
+
+        verifyBaseResponseStructure(TestManager.ACTION_QUIT);
+        verify(terminator).terminate(context, true);
     }
 
     @Test
@@ -177,7 +201,8 @@ public class TestManagerTest {
         Intent intent = intentCaptor.getValue();
         assertNotNull(intent);
         assertEquals(TestManager.TEST_HARNESS_PACKAGE, intent.getPackage());
-        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, intent.getFlags());
+        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK,
+                intent.getFlags());
 
         Uri data = intent.getData();
         assertNotNull(data);

--- a/button-merchant/src/main/AndroidManifest.xml
+++ b/button-merchant/src/main/AndroidManifest.xml
@@ -26,7 +26,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.usebutton.merchant">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <application android:networkSecurityConfig="@xml/network_security_config"/>
+    <permission
+        android:protectionLevel="signature"
+        android:name="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
+
+    <application android:networkSecurityConfig="@xml/network_security_config">
+        <activity
+            android:name=".TestManager$TestExitActivity"
+            android:autoRemoveFromRecents="true"
+            android:permission="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
+    </application>
 
 </manifest>


### PR DESCRIPTION
There is currently an outstanding bug in the Android OS's `ActivityManager` where it persists old Intents for applications that have a non-standard `launchMode` i.e. `singleTask` and `singleInstance`. This bug manifests itself when the host application 's process is force quit.

This PR works around the issue by invoking a temporary Activity which closes itself **and the task it is part of** thereby cleaning up its resources (as far as the ActivityManager is concerned). Optionally, the Brand Test Helper app can request a forced exit -- which will exit the app via a `System.exit(0)` call.

I have also added signature-protected permission to `TestExitActivity` to prevent anyone but the host app from initiating a forced exit.