### PR TITLE
Revert "<Test Helper> Close app by finishing task"

### DIFF
--- a/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
+++ b/button-merchant/src/androidTest/java/com/usebutton/merchant/TestManagerTest.java
@@ -37,8 +37,6 @@ import org.mockito.ArgumentCaptor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -89,7 +87,7 @@ public class TestManagerTest {
         testManager.parseIntent(intent);
 
         verifyBaseResponseStructure(TestManager.ACTION_QUIT);
-        verify(terminator).terminate(eq(context), anyBoolean());
+        verify(terminator).terminate();
     }
 
     @Test
@@ -99,29 +97,7 @@ public class TestManagerTest {
 
         testManager.parseIntent(intent);
 
-        verify(terminator, never()).terminate(eq(context), anyBoolean());
-    }
-
-    @Test
-    public void parseIntent_quit_noForceQuit_shouldNotForceQuit() {
-        Intent intent = createIntentForAction(TestManager.ACTION_QUIT);
-
-        testManager.parseIntent(intent);
-
-        verifyBaseResponseStructure(TestManager.ACTION_QUIT);
-        verify(terminator).terminate(context, false);
-    }
-
-    @Test
-    public void parseIntent_quit_forceQuit_shouldForceQuit() {
-        Uri uri = Uri.parse(String.format("test://home/action/%s?should_force_quit=true",
-                TestManager.ACTION_QUIT));
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-
-        testManager.parseIntent(intent);
-
-        verifyBaseResponseStructure(TestManager.ACTION_QUIT);
-        verify(terminator).terminate(context, true);
+        verify(terminator, never()).terminate();
     }
 
     @Test
@@ -201,8 +177,7 @@ public class TestManagerTest {
         Intent intent = intentCaptor.getValue();
         assertNotNull(intent);
         assertEquals(TestManager.TEST_HARNESS_PACKAGE, intent.getPackage());
-        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK,
-                intent.getFlags());
+        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, intent.getFlags());
 
         Uri data = intent.getData();
         assertNotNull(data);

--- a/button-merchant/src/main/AndroidManifest.xml
+++ b/button-merchant/src/main/AndroidManifest.xml
@@ -26,18 +26,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.usebutton.merchant">
 
-    <permission
-        android:protectionLevel="signature"
-        android:name="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
-
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
-
-    <application android:networkSecurityConfig="@xml/network_security_config">
-        <activity
-            android:name=".TestManager$TestExitActivity"
-            android:autoRemoveFromRecents="true"
-            android:permission="com.usebutton.merchant.TEST_HELPER_PERMISSION" />
-    </application>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:networkSecurityConfig="@xml/network_security_config"/>
 
 </manifest>

--- a/button-merchant/src/main/java/com/usebutton/merchant/TestManager.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/TestManager.java
@@ -25,14 +25,10 @@
 
 package com.usebutton.merchant;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
-import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import java.util.List;
@@ -74,8 +70,7 @@ class TestManager {
             String action = segments.get(1);
             switch (action) {
                 case ACTION_QUIT:
-                    boolean forceQuit = data.getBooleanQueryParameter("should_force_quit", false);
-                    quit(forceQuit);
+                    quit();
                     break;
                 case ACTION_GET_TOKEN:
                     sendToken(ACTION_GET_TOKEN);
@@ -94,7 +89,7 @@ class TestManager {
         }
     }
 
-    private void quit(boolean shouldForceQuit) {
+    private void quit() {
         Uri responseDeeplink = new Uri.Builder()
                 .scheme(TEST_HARNESS_SCHEME)
                 .authority(ACTION_RESPONSE)
@@ -103,7 +98,7 @@ class TestManager {
         boolean successful = submitResult(responseDeeplink);
 
         if (successful) {
-            terminator.terminate(context, shouldForceQuit);
+            terminator.terminate();
         }
     }
 
@@ -142,7 +137,7 @@ class TestManager {
     private boolean submitResult(Uri result) {
         Intent intent = new Intent(Intent.ACTION_VIEW, result);
         intent.setPackage(TEST_HARNESS_PACKAGE);
-        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 
         try {
             context.startActivity(intent);
@@ -156,37 +151,8 @@ class TestManager {
      * Internal class responsible for terminating the host application.
      */
     static class Terminator {
-        void terminate(Context context, boolean shouldForceQuit) {
-            TestExitActivity.exit(context, shouldForceQuit);
-        }
-    }
-
-    public static class TestExitActivity extends Activity {
-
-        private static final String EXTRA_QUIT = "should_force_quit";
-
-        @Override
-        protected void onCreate(@Nullable Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                finishAndRemoveTask();
-            } else {
-                finish();
-            }
-
-            if (getIntent().getBooleanExtra(EXTRA_QUIT, false)) {
-                System.exit(0);
-            }
-        }
-
-        public static void exit(Context context, boolean shouldForceQuit) {
-            Intent intent = new Intent(context, TestExitActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
-                    | Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    | Intent.FLAG_ACTIVITY_NO_ANIMATION
-                    | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-            intent.putExtra(EXTRA_QUIT, shouldForceQuit);
-            context.startActivity(intent);
+        void terminate() {
+            android.os.Process.killProcess(android.os.Process.myPid());
         }
     }
 }


### PR DESCRIPTION
Reverts button/button-merchant-android#75

Non-unique namespacing of the permission caused errors for the consumers of the Library.