### PR TITLE
Retrieve IFA via reflection; Remove Play Ads dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ subprojects {
 
 ext {
     supportLibVersion = '28.0.0'
-    playServicesVersion = '15.0.0'
     junitVersion = '4.13.1'
     mockitoVersion = '2.28.2'
     espressoVersion = '3.0.2'

--- a/button-merchant/build.gradle
+++ b/button-merchant/build.gradle
@@ -61,7 +61,6 @@ configurations {
 
 dependencies {
     implementation "com.android.support:support-annotations:$supportLibVersion"
-    implementation "com.google.android.gms:play-services-ads:$playServicesVersion"
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/button-merchant/src/main/java/com/usebutton/merchant/IdentifierForAdvertiserProvider.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/IdentifierForAdvertiserProvider.java
@@ -1,0 +1,142 @@
+/*
+ * IdentifierForAdvertiserProvider.java
+ *
+ * Copyright (c) 2021 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.content.Context;
+import android.os.Looper;
+import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+class IdentifierForAdvertiserProvider {
+
+    private static final long IFA_TTL = TimeUnit.HOURS.toMillis(1);
+    private final Context context;
+    private TtlReference<AdvertisingInfoReflectionProxy> proxyReference;
+
+    /**
+     * This class can be used to get Advertising ID from the Google Play Services library via
+     * reflection. Will fail silently if not in the classpath, so make sure you have this dependency
+     * in your build.gradle:
+     * {@code implementation 'com.google.android.gms:play-services-ads:20.0.0}
+     */
+    IdentifierForAdvertiserProvider(final Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    /**
+     * This call is blocking and should _not_ be run from the main thread.
+     * For more info: https://developer.android.com/google/play-services/id.html
+     *
+     * @return the Advertising ID if available (Google Play Services on classpath and user have not
+     * disabled tracking).
+     */
+    @Nullable
+    @WorkerThread
+    public String getPrimaryIdentifier() {
+        if (isTrackingLimited() || isOnMainThread()) return null;
+        return getIdentifierProxy().getTrackingIdentifier(context);
+    }
+
+    /**
+     * @return true if ad tracking is limited
+     */
+    public boolean isTrackingLimited() {
+        return getIdentifierProxy().isAdTrackingLimited(context);
+    }
+
+    private AdvertisingInfoReflectionProxy getIdentifierProxy() {
+        if (proxyReference == null || proxyReference.isDead()) {
+            proxyReference = new TtlReference<>(new AdvertisingInfoReflectionProxy(), IFA_TTL);
+        }
+        return proxyReference.get();
+    }
+
+    /**
+     * Intended to keep a cache of methods and objects accessed via reflection for faster access,
+     * but still dynamic enough to get up to date value each time.
+     */
+    private static class AdvertisingInfoReflectionProxy {
+
+        private static final String CLASS =
+                "com.google.android.gms.ads.identifier.AdvertisingIdClient";
+        private static final String METHOD_INFO = "getAdvertisingIdInfo";
+        private static final String METHOD_TRACKING = "isLimitAdTrackingEnabled";
+        private static final String METHOD_IDENTIFIER = "getId";
+
+        private boolean initialized;
+        private Method getInfoMethod;
+        private Class<?> advertisingClient;
+
+        AdvertisingInfoReflectionProxy() {
+            try {
+                advertisingClient = Class.forName(CLASS);
+                getInfoMethod = advertisingClient.getDeclaredMethod(METHOD_INFO, Context.class);
+                initialized = true;
+            } catch (Exception e) {
+                initialized = false;
+            }
+        }
+
+        boolean isAdTrackingLimited(final Context context) {
+            if (!initialized) return false;
+            final Object adInfo;
+            try {
+                adInfo = getAdInfo(context);
+                return (Boolean) adInfo.getClass()
+                        .getMethod(METHOD_TRACKING)
+                        .invoke(adInfo);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        String getTrackingIdentifier(final Context context) {
+            if (!initialized) return null;
+            final Object adInfo;
+            try {
+                adInfo = getAdInfo(context);
+                return (String) adInfo.getClass()
+                        .getMethod(METHOD_IDENTIFIER)
+                        .invoke(adInfo);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private Object getAdInfo(final Context context) throws IllegalAccessException,
+                InvocationTargetException {
+            return getInfoMethod.invoke(advertisingClient, context);
+        }
+    }
+
+    private static boolean isOnMainThread() {
+        return Thread.currentThread() == Looper.getMainLooper().getThread();
+    }
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/TimeProvider.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/TimeProvider.java
@@ -1,0 +1,30 @@
+/*
+ * TimeProvider.java
+ *
+ * Copyright (c) 2021 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+interface TimeProvider {
+    long getTimeInMs();
+}

--- a/button-merchant/src/main/java/com/usebutton/merchant/TtlReference.java
+++ b/button-merchant/src/main/java/com/usebutton/merchant/TtlReference.java
@@ -1,0 +1,85 @@
+/*
+ * TtlReference.java
+ *
+ * Copyright (c) 2021 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import android.os.SystemClock;
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+/**
+ * This class is a convenience class for objects that we want to expire after a certain amount
+ * of time. When the ttl has elapsed against the time provider, {@link #get()} will return null.
+ *
+ * @param <T> type of object we're holding on to
+ */
+class TtlReference<T> {
+
+    public static final TimeProvider REALTIME_MILLIS_PROVIDER = new TimeProvider() {
+        @Override
+        public long getTimeInMs() {
+            return SystemClock.elapsedRealtime();
+        }
+    };
+
+    private final T object;
+    private final long timeOfDeath;
+    private final TimeProvider timeProvider;
+
+    /**
+     *
+     * @param object the object to maintain a reference to
+     * @param ttl positive number of ms object should be accessible
+     */
+    TtlReference(@NonNull T object, @IntRange(from = 1) long ttl) {
+        this(REALTIME_MILLIS_PROVIDER, object, ttl);
+    }
+
+    @VisibleForTesting
+    TtlReference(@NonNull TimeProvider timeProvider, @NonNull T object,
+            @IntRange(from = 1) long ttl) {
+        this.timeProvider = timeProvider;
+        this.object = object;
+        this.timeOfDeath = timeProvider.getTimeInMs() + ttl;
+    }
+
+    /**
+     * @return object or null if ttl has elapsed
+     */
+    public T get() {
+        if (isDead()) {
+            return null;
+        }
+        return object;
+    }
+
+    /**
+     * @return true when ttl has elapsed
+     */
+    public boolean isDead() {
+        return timeProvider.getTimeInMs() > timeOfDeath;
+    }
+}

--- a/button-merchant/src/test/java/com/usebutton/merchant/DeviceManagerImplTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/DeviceManagerImplTest.java
@@ -59,13 +59,15 @@ public class DeviceManagerImplTest {
 
     @Mock
     Context context;
+    @Mock
+    IdentifierForAdvertiserProvider advertiserProvider;
 
     private DeviceManagerImpl deviceManager;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        deviceManager = new DeviceManagerImpl(context);
+        deviceManager = new DeviceManagerImpl(context, advertiserProvider);
     }
 
     @Test
@@ -211,5 +213,12 @@ public class DeviceManagerImplTest {
                 "com.usebutton.merchant/%s+%d (Android null; null null; com.usebutton.app/1.1.0+11; Scale/2.0; en_us)",
                 sdkVersionName, sdkVersionCode);
         assertEquals(expectedUserAgent, userAgent);
+    }
+
+    @Test
+    public void getAdvertisingId_verifyResponse() {
+        when(advertiserProvider.getPrimaryIdentifier()).thenReturn("1337");
+
+        assertEquals("1337", deviceManager.getAdvertisingId());
     }
 }

--- a/button-merchant/src/test/java/com/usebutton/merchant/TtlReferenceTest.java
+++ b/button-merchant/src/test/java/com/usebutton/merchant/TtlReferenceTest.java
@@ -1,0 +1,90 @@
+/*
+ * TtlReferenceTest.java
+ *
+ * Copyright (c) 2021 Button, Inc. (https://usebutton.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.usebutton.merchant;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TtlReferenceTest {
+
+    @Test
+    public void get_expired_shouldReturnNull() {
+        String testObject = "Hello World";
+        TestTimeProvider timeProvider = new TestTimeProvider();
+        TtlReference<String> reference = new TtlReference<>(timeProvider, testObject, 5);
+        timeProvider.setTime(6);
+
+        assertNull(reference.get());
+    }
+
+    @Test
+    public void get_live_shouldReturnValue() {
+        String testObject = "Hello World";
+        TestTimeProvider timeProvider = new TestTimeProvider();
+        TtlReference<String> reference = new TtlReference<>(timeProvider, testObject, 5);
+        timeProvider.setTime(4);
+
+        assertEquals(testObject, reference.get());
+    }
+
+    @Test
+    public void isDead_expired_shouldReturnTrue() {
+        String testObject = "Hello World";
+        TestTimeProvider timeProvider = new TestTimeProvider();
+        TtlReference<String> reference = new TtlReference<>(timeProvider, testObject, 5);
+        timeProvider.setTime(6);
+
+        assertTrue(reference.isDead());
+    }
+
+    @Test
+    public void isDead_live_shouldReturnFalse() {
+        String testObject = "Hello World";
+        TestTimeProvider timeProvider = new TestTimeProvider();
+        TtlReference<String> reference = new TtlReference<>(timeProvider, testObject, 5);
+        timeProvider.setTime(4);
+
+        assertFalse(reference.isDead());
+    }
+
+    private static class TestTimeProvider implements TimeProvider {
+
+        private long time;
+
+        @Override
+        public long getTimeInMs() {
+            return time;
+        }
+
+        public void setTime(long time) {
+            this.time = time;
+        }
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(path: ':button-merchant')
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.google.android.gms:play-services-ads:17.2.1"
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation "com.android.support:design:$supportLibVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -37,13 +37,17 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
On the way towards migration to AndroidX, we would like to reduce the number of dependencies on the Support Library. Once such dependency was the Play Services Ads library, which we were using to retrieve the IFA (Identifier for Advertising). Instead of requesting that dependency directly, this change will rely on the consumer of the Merchant Library to pull in the Ads Library:
```groovy
implementation 'com.google.android.gms:play-services-ads:20.0.0'
```

If available, we will safely interface with it via reflection and retrieve the IFA. If unavailable, we will safely fallback to `null`. This change will continue to respect the "limit ad tracking" setting available to the end-user.

Change was tested on Ads libraries 15.0.0 - 20.2.0