### PR TITLE
adding one line to correspond with our public-facing documentation

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
### Issue Link :link:
Adding one line of to the Manifest file to align with the instructions in our public-facing docs https://developer.usebutton.com/docs/android-add-merchant-library#setup-your-button-links-domain

### Implementation :construction:
this will help ensure a corresponding example exists in this repo

### Testing :mag:
i have not tested anything, although I'm happy to if it is needed
